### PR TITLE
Propagate aspect to generating rules by default

### DIFF
--- a/rules/gather_licenses_info.bzl
+++ b/rules/gather_licenses_info.bzl
@@ -54,6 +54,7 @@ gather_licenses_info = aspect(
     doc = """Collects LicenseInfo providers into a single LicensesInfo provider.""",
     implementation = _gather_licenses_info_impl,
     attr_aspects = ["applicable_licenses", "deps", "srcs"],
+    apply_to_generating_rules = True,
 )
 
 def write_licenses_info(ctx, deps, json_out):


### PR DESCRIPTION
This should make the aspect more reliably collect licenses from included files.

- [ ] Tests pass
- [ ] Tests and examples for any new features.
- [ ] Appropriate changes to README are included in PR
