### PR TITLE
Make default `license_kind` definitions public

### DIFF
--- a/licenses/spdx/BUILD
+++ b/licenses/spdx/BUILD
@@ -41,6 +41,8 @@
 
 load("@rules_license//rules:license_kind.bzl", "license_kind")
 
+package(default_visibility = ["//visibility:public"])
+
 license_kind(
     name = "0BSD",
     conditions = [],


### PR DESCRIPTION
Currently, the default `license_kind` definitions in `//licenses/spdx` can't be used as they are package private.
