### PR TITLE
Update .gitignore file 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 admin/refresh_spdx/licenses.json
+bazel-bin
+bazel-out
+bazel-rules_license
+bazel-testlogs


### PR DESCRIPTION
Update the `.gitignore` file to ignore the following directories generated by `bazel build ...`
```
bazel-bin
bazel-out
bazel-rules_license
bazel-testlogs
```