### PR TITLE
First cut at making a release binary

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -39,3 +39,14 @@ exports_files(
     visibility = ["//visibility:public"],
 )
 
+filegroup(
+    name = "standard_package",
+    srcs = glob([
+        "*.bzl",
+        "*.md",
+    ]) + [
+        "BUILD",
+        "LICENSE",
+    ],
+    visibility = ["//distro:__pkg__"],
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -20,4 +20,17 @@ rules_license_dependencies()
 
 ### INTERNAL ONLY - lines after this are not included in the release packaging.
 
-# TODO(aiuto): Add stardoc dependency eventually.
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "rules_pkg",
+    sha256 = "62eeb544ff1ef41d786e329e1536c1d541bb9bcad27ae984d57f18f314018e66",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.6.0/rules_pkg-0.6.0.tar.gz",
+        "https://github.com/bazelbuild/rules_pkg/releases/download/0.6.0/rules_pkg-0.6.0.tar.gz",
+    ],
+)
+
+load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+
+rules_pkg_dependencies()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,6 +14,7 @@
 
 workspace(name = "rules_license")
 
+# You only need the dependencies if you intend to use any of the tools.
 load("@rules_license//:deps.bzl", "rules_license_dependencies")
 
 rules_license_dependencies()

--- a/distro/BUILD
+++ b/distro/BUILD
@@ -1,0 +1,69 @@
+# Copyright 2022 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//:version.bzl", "version")
+load("@rules_pkg//pkg:pkg.bzl", "pkg_tar")
+load("@rules_pkg//pkg/releasing:defs.bzl", "print_rel_notes")
+
+
+package(
+    default_visibility = ["//visibility:private"],
+    default_applicable_licenses = ["//:license"],
+)
+
+alias(
+    name = "distro",
+    actual = "rules_license-%s" % version,
+)
+
+# Build the artifact to put on the github release page.
+pkg_tar(
+    name = "rules_license-%s" % version,
+    srcs = [
+        ":small_workspace",
+        "//:standard_package",
+        "//licenses/spdx:standard_package",
+        "//rules:standard_package",
+        "//tools:standard_package",
+    ],
+    extension = "tar.gz",
+    # It is all source code, so make it read-only.
+    mode = "0444",
+    # Make it owned by root so it does not have the uid of the CI robot.
+    owner = "0.0",
+    package_dir = ".",
+    strip_prefix = ".",
+    tags = [
+        "no_windows",
+    ],
+)
+
+genrule(
+    name = "small_workspace",
+    srcs = ["//:WORKSPACE"],
+    outs = ["WORKSPACE"],
+    cmd = "sed -e '/### INTERNAL ONLY/,$$d' $(location //:WORKSPACE) >$@",
+    tags = [
+        "no_windows",
+    ],
+)
+
+print_rel_notes(
+    name = "relnotes",
+    outs = ["relnotes.txt"],
+    mirror_host = "mirror.bazel.build",
+    org = "bazelbuild",
+    repo = "rules_license",
+    version = version,
+)

--- a/licenses/spdx/BUILD
+++ b/licenses/spdx/BUILD
@@ -59,6 +59,10 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
+filegroup(
+    name = "standard_package",
+    srcs = ["BUILD"],
+)
 
 license_kind(
     name = "0BSD",

--- a/rules/BUILD
+++ b/rules/BUILD
@@ -21,3 +21,8 @@ package(
     default_applicable_licenses = ["//:license"],
     default_visibility = ["//visibility:public"],
 )
+
+filegroup(
+    name = "standard_package",
+    srcs = glob(["**"]),
+)

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -27,3 +27,9 @@ py_binary(
 )
 
 exports_files(["diff_test.sh"])
+
+filegroup(
+    name = "standard_package",
+    srcs = glob(["**"]),
+    visibility = ["//distro:__pkg__"],
+)


### PR DESCRIPTION
This PR adds the framework to make a release binary that should be used by any rule set that just wants to declare a license.  As such, the package does not depend on any other rules.

This is the first of several PRs which will bootstrap a steady state.
- this PR
- cut a release
- update rules_pkg to use the release
- cut a rules_pkg release
- verify we can depend on each other correctly in this embrace
- vendor this package to bazelbuild/bazel
- produce compliance report showing rules_pkg licensing
- iterate through other repositories.