### PR TITLE
Do some things to make buildifier happy

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -22,7 +22,7 @@ package(
 license(
     name = "license",
     license_kinds = [
-        "@rules_license//licenses/spdx:Apache-2.0"
+        "@rules_license//licenses/spdx:Apache-2.0",
     ],
     license_text = "LICENSE",
 )
@@ -38,4 +38,3 @@ exports_files(
     ]),
     visibility = ["//visibility:public"],
 )
-

--- a/deps.bzl
+++ b/deps.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Workspace dependencies for rules_license/rules
+"""Workspace dependencies for rules_license/rules."""
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")

--- a/examples/src/BUILD
+++ b/examples/src/BUILD
@@ -1,7 +1,7 @@
 # Examples of applications and interactions with licenses
 
 load("@rules_license//examples/vendor/constant_gen:defs.bzl", "constant_gen")
-load("@rules_license//rules:compliance.bzl", "check_license", "licenses_used")
+load("@rules_license//rules:compliance.bzl", "licenses_used")
 load("@rules_license//rules:license_policy_check.bzl", "license_policy_check")
 load("@rules_license//tools:test_helpers.bzl", "golden_test")
 

--- a/examples/vendor/constant_gen/BUILD
+++ b/examples/vendor/constant_gen/BUILD
@@ -1,9 +1,9 @@
 # An example of a code generator with a distinct license for the generated code.
 
-load(":defs.bzl", "constant_gen")
 load("@rules_license//rules:compliance.bzl", "licenses_used")
 load("@rules_license//rules:license.bzl", "license")
 load("@rules_license//tools:test_helpers.bzl", "golden_test")
+load(":defs.bzl", "constant_gen")
 
 package(
     default_applicable_licenses = [":license"],

--- a/licenses/generic/BUILD
+++ b/licenses/generic/BUILD
@@ -1,4 +1,18 @@
-# license_kind()s for generic license identifiers.
+# Copyright 2022 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""license_kind()s for generic license identifiers."""
 
 # This is a set of license_kind declarations based on the legacy Bazel license
 # identifiers.

--- a/licenses/spdx/BUILD
+++ b/licenses/spdx/BUILD
@@ -59,7 +59,6 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
-
 license_kind(
     name = "0BSD",
     conditions = [],

--- a/licenses/spdx/BUILD
+++ b/licenses/spdx/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# license_kind()s for SPDX license identifiers.
+"""license_kind()s for SPDX license identifiers."""
 
 # This is a set of license_kind declarations based on the SPDX license
 # identifiers.  See: https://spdx.org/licenses/

--- a/rules/BUILD
+++ b/rules/BUILD
@@ -13,7 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Rules for declaring licenses used."""
+"""Rules for making license declarations."""
 
 package(
     default_applicable_licenses = ["//:license"],

--- a/rules/BUILD
+++ b/rules/BUILD
@@ -13,9 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# TODO(aiuto): Add dependency on Skylib for bzl_library so that we can later
-# generate docs with stardoc.
+"""Rules for declaring licenses used."""
 
 package(
     default_applicable_licenses = ["//:license"],

--- a/rules/compliance.bzl
+++ b/rules/compliance.bzl
@@ -15,13 +15,13 @@
 """Proof of concept. License compliance checking."""
 
 load(
-    "@rules_license//rules:providers.bzl",
-    "LicensesInfo",
-)
-load(
     "@rules_license//rules:gather_licenses_info.bzl",
     "gather_licenses_info",
     "write_licenses_info",
+)
+load(
+    "@rules_license//rules:providers.bzl",
+    "LicensesInfo",
 )
 
 # Debugging verbosity
@@ -75,11 +75,11 @@ def _check_license_impl(ctx):
 _check_license = rule(
     implementation = _check_license_impl,
     attrs = {
+        "check_conditions": attr.bool(default = True, mandatory = False),
+        "copyright_notices": attr.output(mandatory = False),
         "deps": attr.label_list(
             aspects = [gather_licenses_info],
         ),
-        "check_conditions": attr.bool(default = True, mandatory = False),
-        "copyright_notices": attr.output(mandatory = False),
         "license_texts": attr.output(mandatory = False),
         "report": attr.output(mandatory = True),
         "_checker": attr.label(

--- a/rules/default_license.bzl
+++ b/rules/default_license.bzl
@@ -47,6 +47,7 @@ _default_licenses = rule(
     },
 )
 
+# buildifier: disable=unamed-macro
 def default_licenses(licenses, conditions = None):
     _default_licenses(
         name = "__default_licenses",

--- a/rules/default_license.bzl
+++ b/rules/default_license.bzl
@@ -17,7 +17,6 @@
 load(
     "@rules_license//rules:providers.bzl",
     "LicenseInfo",
-    "LicenseKindInfo",
     "LicensesInfo",
 )
 
@@ -35,14 +34,14 @@ def _default_licenses_impl(ctx):
 _default_licenses = rule(
     implementation = _default_licenses_impl,
     attrs = {
+        "conditions": attr.string_list(
+            doc = "TBD",
+        ),
         "deps": attr.label_list(
             mandatory = True,
             doc = "Licenses",
             providers = [LicenseInfo],
             cfg = "host",
-        ),
-        "conditions": attr.string_list(
-            doc = "",
         ),
     },
 )

--- a/rules/default_license.bzl
+++ b/rules/default_license.bzl
@@ -47,10 +47,10 @@ _default_licenses = rule(
     },
 )
 
-# buildifier: disable=unamed-macro
+# buildifier: disable=unnamed-macro
 def default_licenses(licenses, conditions = None):
     _default_licenses(
         name = "__default_licenses",
-        deps = ["%s_license" % l for l in licenses],
+        deps = ["%s_license" % license for license in licenses],
         conditions = conditions,
     )

--- a/rules/license.bzl
+++ b/rules/license.bzl
@@ -45,6 +45,9 @@ def _license_impl(ctx):
 _license = rule(
     implementation = _license_impl,
     attrs = {
+        "copyright_notice": attr.string(
+            doc = "Copyright notice.",
+        ),
         "license_kinds": attr.label_list(
             mandatory = True,
             doc = "License kind(s) of this license. If multiple license kinds are" +
@@ -53,9 +56,6 @@ _license = rule(
                   " of many, then only list one here.",
             providers = [LicenseKindInfo],
             cfg = "host",
-        ),
-        "copyright_notice": attr.string(
-            doc = "Copyright notice.",
         ),
         "license_text": attr.label(
             allow_single_file = True,

--- a/rules/license_kind.bzl
+++ b/rules/license_kind.bzl
@@ -37,14 +37,14 @@ def _license_kind_impl(ctx):
 _license_kind = rule(
     implementation = _license_kind_impl,
     attrs = {
+        "canonical_text": attr.label(
+            doc = "File containing the canonical text for this license. Must be UTF-8 encoded.",
+            allow_single_file = True,
+        ),
         "conditions": attr.string_list(
             doc = "Conditions to be met when using software under this license." +
                   "  Conditions are defined by the organization using this license.",
             mandatory = True,
-        ),
-        "canonical_text": attr.label(
-            doc = "File containing the canonical text for this license. Must be UTF-8 encoded.",
-            allow_single_file = True,
         ),
         "url": attr.string(doc = "URL pointing to canonical license definition"),
     },

--- a/rules/license_policy_check.bzl
+++ b/rules/license_policy_check.bzl
@@ -15,16 +15,16 @@
 """License compliance checking at analysis time."""
 
 load(
-    "@rules_license//rules:providers.bzl",
-    "LicensesInfo",
-)
-load(
     "@rules_license//rules:gather_licenses_info.bzl",
     "gather_licenses_info",
 )
 load(
     "@rules_license//rules:license_policy_provider.bzl",
     "LicensePolicyInfo",
+)
+load(
+    "@rules_license//rules:providers.bzl",
+    "LicensesInfo",
 )
 
 def _license_policy_check_impl(ctx):
@@ -46,16 +46,16 @@ _license_policy_check = rule(
     implementation = _license_policy_check_impl,
     doc = """Internal tmplementation method for license_policy_check().""",
     attrs = {
+        "policy": attr.label(
+            doc = """Policy definition.""",
+            mandatory = True,
+            providers = [LicensePolicyInfo],
+        ),
         "target": attr.label(
             doc = """Target to collect LicenseInfo for.""",
             aspects = [gather_licenses_info],
             mandatory = True,
             allow_single_file = True,
-        ),
-        "policy": attr.label(
-            doc = """Policy definition.""",
-            mandatory = True,
-            providers = [LicensePolicyInfo],
         ),
     },
 )

--- a/rules/license_policy_provider.bzl
+++ b/rules/license_policy_provider.bzl
@@ -17,8 +17,8 @@
 LicensePolicyInfo = provider(
     doc = """Declares a policy name and the license conditions allowable under it.""",
     fields = {
-        "name": "License Policy Name",
-        "label": "The full path to the license policy definition.",
         "conditions": "List of conditions to be met when using this software.",
+        "label": "The full path to the license policy definition.",
+        "name": "License policy name",
     },
 )

--- a/rules/providers.bzl
+++ b/rules/providers.bzl
@@ -17,9 +17,9 @@
 LicenseKindInfo = provider(
     doc = """Provides information about a license kind.""",
     fields = {
-        "name": "License Name",
-        "label": "The full path to the license kind definition.",
         "conditions": "List of conditions to be met when using this software.",
+        "label": "The full path to the license kind definition.",
+        "name": "License Name",
     },
 )
 

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -1,4 +1,4 @@
-# Test cases for license rules.
+"""Test cases for license rules."""
 
 load("@rules_license//rules:compliance.bzl", "check_license")
 load("@rules_license//rules:license.bzl", "license")

--- a/tests/Bar.java
+++ b/tests/Bar.java
@@ -13,8 +13,11 @@
 // limitations under the License.
 
 /**
- *
+ * A java class.
  */
+
+package build.bazel.rules_license.tests;
+
 final class Bar {
 
   static final int PI = 3;

--- a/tests/Hello.java
+++ b/tests/Hello.java
@@ -13,8 +13,11 @@
 // limitations under the License.
 
 /**
- *
+ * A java main.
  */
+
+package build.bazel.rules_license.tests;
+
 final class Hello {
 
   private Hello() {

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# License declaration and compliance checking tools.
+"""License declaration and compliance checking tools."""
 
 package(
     default_applicable_licenses = ["//:license"],


### PR DESCRIPTION
Some things that make buildifier a little happier. That makes it easier for people to vendor it in.
- add docstrings
- suppress warning about the default_licenses rule
