### PR TITLE
Add additional_info attribute for licences.

### DIFF
--- a/examples/vendor/acme/BUILD
+++ b/examples/vendor/acme/BUILD
@@ -10,6 +10,9 @@ package(
 # The default license for an entire package is typically named "license".
 license(
     name = "license",
+    additional_info = {
+        "homepage": "https://example.com",
+    },
     license_kinds = [
         "@rules_license//examples/my_org/licenses:acme_corp_paid",
     ],

--- a/rules/providers.bzl
+++ b/rules/providers.bzl
@@ -31,6 +31,8 @@ LicenseInfo = provider(
         "license_text": "License file",
         "package_name": "Human readable package name",
         "rule": "From whence this came",
+        "additional_info": "A string-string dictionary containing " +
+                           "arbitrary additional metadata.",
     },
 )
 


### PR DESCRIPTION
This attribute was specified in the design doc but was not present in
the implementation.

Closes #32.

In passing, also fix an issue with the macro wrapper for `license` where
it was specifying `license_kind` as a keyword argument and then also
trying to pop it from `kwargs`.  It wouldn't ever be present there,
because of the keyword arg.

- [x] Tests pass
- [x] Examples for any new features.
- [x] Appropriate changes to README are included in PR (n/a, because the readme is still pretty bare-bones).
