### PR TITLE
add generic license list

### DIFF
--- a/distro/BUILD
+++ b/distro/BUILD
@@ -33,6 +33,7 @@ pkg_tar(
     srcs = [
         ":small_workspace",
         "//:standard_package",
+        "//licenses/generic:standard_package",
         "//licenses/spdx:standard_package",
         "//rules:standard_package",
         "//tools:standard_package",

--- a/licenses/generic/BUILD
+++ b/licenses/generic/BUILD
@@ -35,8 +35,12 @@
 # Packages may create license rules that use these license_kinds when the
 # package has provided a LICENSE file, but the text in it  does not match any
 # of the well known licenses in @rules_license//licenses/spdx:*
-
 load("@rules_license//rules:license_kind.bzl", "license_kind")
+
+filegroup(
+    name = "standard_package",
+    srcs = ["BUILD"],
+)
 
 package(
     default_applicable_licenses = ["//:license"],

--- a/version.bzl
+++ b/version.bzl
@@ -13,4 +13,4 @@
 # limitations under the License.
 """The version of rules_license."""
 
-version = "0.0.2"
+version = "0.0.3"


### PR DESCRIPTION
I missed the generic license list.  Adding this and bumping version to 0.0.3 to make another release so I start injecting into bazel.