### PR TITLE
Add legacy licenses([notice]) clauses to the build files.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -19,6 +19,8 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
+licenses(["notice"])
+
 license(
     name = "license",
     license_kinds = [
@@ -28,7 +30,7 @@ license(
 )
 
 exports_files(
-    ["WORKSPACE"],
+    ["LICENSE", "WORKSPACE"],
     visibility = ["//visibility:public"],
 )
 

--- a/distro/BUILD
+++ b/distro/BUILD
@@ -16,11 +16,12 @@ load("//:version.bzl", "version")
 load("@rules_pkg//pkg:pkg.bzl", "pkg_tar")
 load("@rules_pkg//pkg/releasing:defs.bzl", "print_rel_notes")
 
-
 package(
     default_visibility = ["//visibility:private"],
     default_applicable_licenses = ["//:license"],
 )
+
+licenses(["notice"])
 
 alias(
     name = "distro",

--- a/licenses/generic/BUILD
+++ b/licenses/generic/BUILD
@@ -37,14 +37,16 @@
 # of the well known licenses in @rules_license//licenses/spdx:*
 load("@rules_license//rules:license_kind.bzl", "license_kind")
 
-filegroup(
-    name = "standard_package",
-    srcs = ["BUILD"],
-)
-
 package(
     default_applicable_licenses = ["//:license"],
     default_visibility = ["//visibility:public"],
+)
+
+licenses(["notice"])
+
+filegroup(
+    name = "standard_package",
+    srcs = ["BUILD"],
 )
 
 # "none" should be used for packages which are distributed with no license of

--- a/licenses/spdx/BUILD
+++ b/licenses/spdx/BUILD
@@ -59,6 +59,8 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
+licenses(["notice"])
+
 filegroup(
     name = "standard_package",
     srcs = ["BUILD"],

--- a/rules/BUILD
+++ b/rules/BUILD
@@ -20,6 +20,8 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
+licenses(["notice"])
+
 filegroup(
     name = "standard_package",
     srcs = glob(["**"]),

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -7,6 +7,8 @@ load("@rules_license//tools:test_helpers.bzl", "golden_test")
 
 package(default_applicable_licenses = [":license"])
 
+licenses(["notice"])
+
 # license_kind rules generally appear in a central location per workspace. They
 # are intermingled with normal target build rules
 license_kind(

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -19,6 +19,8 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
+licenses(["notice"])
+
 py_binary(
     name = "checker_demo",
     srcs = ["checker_demo.py"],


### PR DESCRIPTION
This is an utterly stupid change. It is just to make it easier to import the code into Google. That, in turn, makes it easier to work towards converging the two code bases.