### PR TITLE
more workarounds for a changing bazel

### DIFF
--- a/rules/gather_licenses_info.bzl
+++ b/rules/gather_licenses_info.bzl
@@ -36,6 +36,8 @@ def _strip_null_repo(label):
     s = str(label)
     if s.startswith('@//'):
         return s[1:]
+    elif s.startswith('@@//'):
+        return s[2:]
     return s
 
 def _gather_licenses_info_impl(target, ctx):


### PR DESCRIPTION
Fixes disparity between handling str(Label) in Bazel 5, 6, & head.
Depending on the version and bzlmod being enabled you can get  //pkg:x, @//pkg:x, or @@//pkg:x.
