### PR TITLE
Add package_info rule and a new gatherer to collect it.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -13,9 +13,11 @@
 # limitations under the License.
 
 load("@rules_license//rules:license.bzl", "license")
+load("@rules_license//rules:package_info.bzl", "package_info")
+load("@rules_license//:version.bzl", "version")
 
 package(
-    default_applicable_licenses = [":license"],
+    default_applicable_licenses = [":license", ":package_info"],
     default_visibility = ["//visibility:public"],
 )
 
@@ -27,6 +29,12 @@ license(
         "@rules_license//licenses/spdx:Apache-2.0",
     ],
     license_text = "LICENSE",
+)
+
+package_info(
+    name = "package_info",
+    package_name = "rules_license",
+    package_version = version,
 )
 
 exports_files(

--- a/examples/sboms/BUILD
+++ b/examples/sboms/BUILD
@@ -1,0 +1,13 @@
+# Demonstrate the generate_sbom rule
+
+load("@rules_license//rules:sbom.bzl", "generate_sbom")
+
+# There are not a lot of targets in this rule set to build a SBOM from
+# so we will (in a very self-referential way) generate one for the tool
+# which generates the SBOMs
+# See the output in bazel-bin/examples/sboms/write_sbom.txt
+generate_sbom(
+    name = "write_sbom_sbom",
+    out = "write_sbom.txt",
+    deps = ["//tools:write_sbom"],
+)

--- a/rules/gather_metadata.bzl
+++ b/rules/gather_metadata.bzl
@@ -21,7 +21,9 @@ load(
 )
 load(
     "@rules_license//rules:providers.bzl",
-    "TransitiveLicensesInfo",
+    "MetadataInfo",
+    "PackageInfo",
+    "TransitiveMetadataInfo",
 )
 
 # Definition for compliance namespace, used for filtering licenses
@@ -40,21 +42,25 @@ def _strip_null_repo(label):
         return s[2:]
     return s
 
-def _gather_licenses_info_impl(target, ctx):
-    return gather_metadata_info_common(target, ctx, TransitiveLicensesInfo, NAMESPACES, [], should_traverse)
+def _bazel_package(label):
+    l = _strip_null_repo(label)
+    return l[0:-(len(label.name) + 1)]
 
-gather_licenses_info = aspect(
-    doc = """Collects LicenseInfo providers into a single TransitiveLicensesInfo provider.""",
-    implementation = _gather_licenses_info_impl,
+def _gather_metadata_info_impl(target, ctx):
+    return gather_metadata_info_common(target, ctx, TransitiveMetadataInfo, NAMESPACES, [MetadataInfo, PackageInfo], should_traverse)
+
+gather_metadata_info = aspect(
+    doc = """Collects LicenseInfo providers into a single TransitiveMetadataInfo provider.""",
+    implementation = _gather_metadata_info_impl,
     attr_aspects = ["*"],
     attrs = {
         "_trace": attr.label(default = "@rules_license//rules:trace_target"),
     },
-    provides = [TransitiveLicensesInfo],
+    provides = [TransitiveMetadataInfo],
     apply_to_generating_rules = True,
 )
 
-def _write_licenses_info_impl(target, ctx):
+def _write_metadata_info_impl(target, ctx):
     """Write transitive license info into a JSON file
 
     Args:
@@ -65,9 +71,9 @@ def _write_licenses_info_impl(target, ctx):
       OutputGroupInfo
     """
 
-    if not TransitiveLicensesInfo in target:
+    if not TransitiveMetadataInfo in target:
         return [OutputGroupInfo(licenses = depset())]
-    info = target[TransitiveLicensesInfo]
+    info = target[TransitiveMetadataInfo]
     outs = []
 
     # If the result doesn't contain licenses, we simply return the provider
@@ -75,8 +81,8 @@ def _write_licenses_info_impl(target, ctx):
         return [OutputGroupInfo(licenses = depset())]
 
     # Write the output file for the target
-    name = "%s_licenses_info.json" % ctx.label.name
-    content = "[\n%s\n]\n" % ",\n".join(licenses_info_to_json(info))
+    name = "%s_metadata_info.json" % ctx.label.name
+    content = "[\n%s\n]\n" % ",\n".join(metadata_info_to_json(info))
     out = ctx.actions.declare_file(name)
     ctx.actions.write(
         output = out,
@@ -91,69 +97,69 @@ def _write_licenses_info_impl(target, ctx):
 
     return [OutputGroupInfo(licenses = depset(outs))]
 
-gather_licenses_info_and_write = aspect(
-    doc = """Collects TransitiveLicensesInfo providers and writes JSON representation to a file.
+gather_metadata_info_and_write = aspect(
+    doc = """Collects TransitiveMetadataInfo providers and writes JSON representation to a file.
 
     Usage:
       blaze build //some:target \
-          --aspects=@rules_license//rules:gather_licenses_info.bzl%gather_licenses_info_and_write
+          --aspects=@rules_license//rules:gather_metadata_info.bzl%gather_metadata_info_and_write
           --output_groups=licenses
     """,
-    implementation = _write_licenses_info_impl,
+    implementation = _write_metadata_info_impl,
     attr_aspects = ["*"],
     attrs = {
         "_trace": attr.label(default = "@rules_license//rules:trace_target"),
     },
     provides = [OutputGroupInfo],
-    requires = [gather_licenses_info],
+    requires = [gather_metadata_info],
     apply_to_generating_rules = True,
 )
 
-def write_licenses_info(ctx, deps, json_out):
-    """Writes TransitiveLicensesInfo providers for a set of targets as JSON.
+def write_metadata_info(ctx, deps, json_out):
+    """Writes TransitiveMetadataInfo providers for a set of targets as JSON.
 
     TODO(aiuto): Document JSON schema. But it is under development, so the current
     best place to look is at tests/hello_licenses.golden.
 
     Usage:
-      write_licenses_info must be called from a rule implementation, where the
-      rule has run the gather_licenses_info aspect on its deps to
+      write_metadata_info must be called from a rule implementation, where the
+      rule has run the gather_metadata_info aspect on its deps to
       collect the transitive closure of LicenseInfo providers into a
       LicenseInfo provider.
 
       foo = rule(
         implementation = _foo_impl,
         attrs = {
-           "deps": attr.label_list(aspects = [gather_licenses_info])
+           "deps": attr.label_list(aspects = [gather_metadata_info])
         }
       )
 
       def _foo_impl(ctx):
         ...
         out = ctx.actions.declare_file("%s_licenses.json" % ctx.label.name)
-        write_licenses_info(ctx, ctx.attr.deps, licenses_file)
+        write_metadata_info(ctx, ctx.attr.deps, metadata_file)
 
     Args:
       ctx: context of the caller
-      deps: a list of deps which should have TransitiveLicensesInfo providers.
-            This requires that you have run the gather_licenses_info
+      deps: a list of deps which should have TransitiveMetadataInfo providers.
+            This requires that you have run the gather_metadata_info
             aspect over them
       json_out: output handle to write the JSON info
     """
     licenses = []
     for dep in deps:
-        if TransitiveLicensesInfo in dep:
-            licenses.extend(licenses_info_to_json(dep[TransitiveLicensesInfo]))
+        if TransitiveMetadataInfo in dep:
+            licenses.extend(metadata_info_to_json(dep[TransitiveMetadataInfo]))
     ctx.actions.write(
         output = json_out,
         content = "[\n%s\n]\n" % ",\n".join(licenses),
     )
 
-def licenses_info_to_json(licenses_info):
+def metadata_info_to_json(metadata_info):
     """Render a single LicenseInfo provider to JSON
 
     Args:
-      licenses_info: A LicenseInfo.
+      metadata_info: A LicenseInfo.
 
     Returns:
       [(str)] list of LicenseInfo values rendered as JSON.
@@ -164,6 +170,8 @@ def licenses_info_to_json(licenses_info):
     "dependencies": [{dependencies}
     ],
     "licenses": [{licenses}
+    ],
+    "packages": [{packages}
     ]\n  }}"""
 
     dep_template = """
@@ -174,11 +182,10 @@ def licenses_info_to_json(licenses_info):
         ]
       }}"""
 
-    # TODO(aiuto): 'rule' is a duplicate of 'label' until old users are transitioned
     license_template = """
       {{
         "label": "{label}",
-        "rule": "{label}",
+        "bazel_package": "{bazel_package}",
         "license_kinds": [{kinds}
         ],
         "copyright_notice": "{copyright_notice}",
@@ -198,9 +205,18 @@ def licenses_info_to_json(licenses_info):
             "conditions": {kind_conditions}
           }}"""
 
+    package_info_template = """
+          {{
+            "target": "{label}",
+            "bazel_package": "{bazel_package}",
+            "package_name": "{package_name}",
+            "package_url": "{package_url}",
+            "package_version": "{package_version}"
+          }}"""
+
     # Build reverse map of license to user
     used_by = {}
-    for dep in licenses_info.deps.to_list():
+    for dep in metadata_info.deps.to_list():
         # Undo the concatenation applied when stored in the provider.
         dep_licenses = dep.licenses.split(",")
         for license in dep_licenses:
@@ -209,7 +225,7 @@ def licenses_info_to_json(licenses_info):
             used_by[license].append(_strip_null_repo(dep.target_under_license))
 
     all_licenses = []
-    for license in sorted(licenses_info.licenses.to_list(), key = lambda x: x.label):
+    for license in sorted(metadata_info.licenses.to_list(), key = lambda x: x.label):
         kinds = []
         for kind in sorted(license.license_kinds, key = lambda x: x.name):
             kinds.append(kind_template.format(
@@ -229,12 +245,13 @@ def licenses_info_to_json(licenses_info):
                 package_url = license.package_url,
                 package_version = license.package_version,
                 label = _strip_null_repo(license.label),
+                bazel_package =  _bazel_package(license.label),
                 used_by = ",\n          ".join(sorted(['"%s"' % x for x in used_by[str(license.label)]])),
             ))
 
     all_deps = []
-    for dep in sorted(licenses_info.deps.to_list(), key = lambda x: x.target_under_license):
-        licenses_used = []
+    for dep in sorted(metadata_info.deps.to_list(), key = lambda x: x.target_under_license):
+        metadata_used = []
 
         # Undo the concatenation applied when stored in the provider.
         dep_licenses = dep.licenses.split(",")
@@ -243,8 +260,44 @@ def licenses_info_to_json(licenses_info):
             licenses = ",\n          ".join(sorted(['"%s"' % _strip_null_repo(x) for x in dep_licenses])),
         ))
 
+    all_packages = []
+    # We would use this if we had distinct depsets for every provider type.
+    #for package in sorted(metadata_info.package_info.to_list(), key = lambda x: x.label):
+    #    all_packages.append(package_info_template.format(
+    #        label = _strip_null_repo(package.label),
+    #        copyright_notice = package.copyright_notice,
+    #        package_name = package.package_name,
+    #        package_url = package.package_url,
+    #        package_version = package.package_version,
+    #    ))
+
+    for mi in sorted(metadata_info.other_metadata.to_list(), key = lambda x: x.label):
+        # Maybe use a map of provider class to formatter.  A generic dict->json function
+        # in starlark would help
+
+        # This format is for using distinct providers.  I like the compile time safety.
+        if mi.type == "package_info":
+            all_packages.append(package_info_template.format(
+                label = _strip_null_repo(mi.label),
+                bazel_package =  _bazel_package(mi.label),
+                package_name = mi.package_name,
+                package_url = mi.package_url,
+                package_version = mi.package_version,
+            ))
+        # experimental: Support the MetadataInfo bag of data
+        if mi.type == "package_info_alt":
+            all_packages.append(package_info_template.format(
+                label = _strip_null_repo(mi.label),
+                bazel_package =  _bazel_package(mi.label),
+                # data is just a bag, so we need to use get() or ""
+                package_name = mi.data.get("package_name") or "",
+                package_url = mi.data.get("package_url") or "",
+                package_version = mi.data.get("package_version") or "",
+            ))
+
     return [main_template.format(
-        top_level_target = _strip_null_repo(licenses_info.target_under_license),
+        top_level_target = _strip_null_repo(metadata_info.target_under_license),
         dependencies = ",".join(all_deps),
         licenses = ",".join(all_licenses),
+        packages = ",".join(all_packages),
     )]

--- a/rules/gather_metadata.bzl
+++ b/rules/gather_metadata.bzl
@@ -101,7 +101,7 @@ gather_metadata_info_and_write = aspect(
     doc = """Collects TransitiveMetadataInfo providers and writes JSON representation to a file.
 
     Usage:
-      blaze build //some:target \
+      bazel build //some:target \
           --aspects=@rules_license//rules:gather_metadata_info.bzl%gather_metadata_info_and_write
           --output_groups=licenses
     """,
@@ -265,7 +265,6 @@ def metadata_info_to_json(metadata_info):
     #for package in sorted(metadata_info.package_info.to_list(), key = lambda x: x.label):
     #    all_packages.append(package_info_template.format(
     #        label = _strip_null_repo(package.label),
-    #        copyright_notice = package.copyright_notice,
     #        package_name = package.package_name,
     #        package_url = package.package_url,
     #        package_version = package.package_version,

--- a/rules/package_info.bzl
+++ b/rules/package_info.bzl
@@ -1,0 +1,106 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Rules for declaring metadata about a package."""
+
+load(
+    "@rules_license//rules:providers.bzl",
+    "MetadataInfo",
+    "PackageInfo",
+)
+
+#
+# package_info()
+#
+
+def _package_info_impl(ctx):
+    provider = PackageInfo(
+        # Metadata providers must include a type discriminator. We don't need it
+        # to collect the providers, but we do need it to write the JSON. We
+        # key on the type field to look up the correct block of code to pull
+        # data out and format it. We can't to the lookup on the provider class.
+        type = "package_info",
+        label = ctx.label,
+        package_name = ctx.attr.package_name or ctx.build_file_path.rstrip("/BUILD"),
+        package_url = ctx.attr.package_url,
+        package_version = ctx.attr.package_version,
+    )
+    # Experimental alternate design, using a generic 'data' back to hold things
+    generic_provider = MetadataInfo(
+        type = "package_info_alt",
+        label = ctx.label,
+        data = {
+            "package_name": ctx.attr.package_name or ctx.build_file_path.rstrip("/BUILD"),
+            "package_url": ctx.attr.package_url,
+            "package_version": ctx.attr.package_version
+        }
+    )
+    return [provider, generic_provider]
+
+_package_info = rule(
+    implementation = _package_info_impl,
+    attrs = {
+        "copyright_notice": attr.string(
+            doc = "Copyright notice.",
+        ),
+        "package_name": attr.string(
+            doc = "A human readable name identifying this package." +
+                  " This may be used to produce an index of OSS packages used by" +
+                  " an applicatation.",
+        ),
+        "package_url": attr.string(
+            doc = "The URL this instance of the package was download from." +
+                  " This may be used to produce an index of OSS packages used by" +
+                  " an applicatation.",
+        ),
+        "package_version": attr.string(
+            doc = "A human readable version string identifying this package." +
+                  " This may be used to produce an index of OSS packages used" +
+                  " by an applicatation.  It should be a value that" +
+                  " increases over time, rather than a commit hash."
+        ),
+    },
+)
+
+# buildifier: disable=function-docstring-args
+def package_info(
+        name,
+        copyright_notice = None,
+        package_name = None,
+        package_url = None,
+        package_version = None,
+        visibility = ["//visibility:public"]):
+    """Wrapper for package_info rule.
+
+    Args:
+      name: str target name.
+      license_kind: label a single license_kind. Only one of license_kind or license_kinds may
+                    be specified
+      license_kinds: list(label) list of license_kind targets.
+      copyright_notice: str Copyright notice associated with this package.
+      package_name : str A human readable name identifying this package. This
+                     may be used to produce an index of OSS packages used by
+                     an application.
+      tags: list(str) tags applied to the rule
+    """
+    _package_info(
+        name = name,
+        copyright_notice = copyright_notice,
+        package_name = package_name,
+        package_url = package_url,
+        package_version = package_version,
+        applicable_licenses = [],
+        visibility = visibility,
+        tags = [],
+        testonly = 0,
+    )

--- a/rules/package_info.bzl
+++ b/rules/package_info.bzl
@@ -50,9 +50,6 @@ def _package_info_impl(ctx):
 _package_info = rule(
     implementation = _package_info_impl,
     attrs = {
-        "copyright_notice": attr.string(
-            doc = "Copyright notice.",
-        ),
         "package_name": attr.string(
             doc = "A human readable name identifying this package." +
                   " This may be used to produce an index of OSS packages used by" +
@@ -75,7 +72,6 @@ _package_info = rule(
 # buildifier: disable=function-docstring-args
 def package_info(
         name,
-        copyright_notice = None,
         package_name = None,
         package_url = None,
         package_version = None,
@@ -84,18 +80,16 @@ def package_info(
 
     Args:
       name: str target name.
-      license_kind: label a single license_kind. Only one of license_kind or license_kinds may
-                    be specified
-      license_kinds: list(label) list of license_kind targets.
-      copyright_notice: str Copyright notice associated with this package.
       package_name : str A human readable name identifying this package. This
                      may be used to produce an index of OSS packages used by
                      an application.
-      tags: list(str) tags applied to the rule
+      package_url: str The canoncial URL this package distribution was retrieved from.
+                       Note that, because of local mirroring, that might not be the 
+                       physical URL it was retrieved from.
+      package_version: str A human readable name identifying version of this package.
     """
     _package_info(
         name = name,
-        copyright_notice = copyright_notice,
         package_name = package_name,
         package_url = package_url,
         package_version = package_version,

--- a/rules/providers.bzl
+++ b/rules/providers.bzl
@@ -87,12 +87,12 @@ MetadataInfo = provider(
 TransitiveMetadataInfo = provider(
     doc = """The transitive set of licenses used by a target.""",
     fields = {
-        "top_level_target": "Label: The top level target label.",
+        "top_level_target": "Label: The top level target label we are examining.",
         "other_metadata": "depset(MetatdataInfo)",
         "licenses": "depset(LicenseInfo)",
         "package_info": "depset(PackageInfo)",
 
-        "target_under_license": "Label: The top level target label.",
+        "target_under_license": "Label: A target which will be associated with some licenses.",
         "deps": "depset(LicensedTargetInfo): The transitive list of dependencies that have licenses.",
         "traces": "list(string) - diagnostic for tracing a dependency relationship to a target.",
     },

--- a/rules/providers.bzl
+++ b/rules/providers.bzl
@@ -59,3 +59,41 @@ def licenses_info():
 
 # This provider is used by the aspect that is used by manifest() rules.
 TransitiveLicensesInfo = licenses_info()
+
+# This is one way to do specify data
+PackageInfo = provider(
+    doc = """Provides information about a package.""",
+    fields = {
+        "type": "string: How to interpret data",
+        "label": "Label: label of the package_info rule",
+        "package_name": "string: Human readable package name",
+        "package_url": "string: URL from which this package was downloaded.",
+        "package_version": "string: Human readable version string",
+    },
+)
+
+# This is more extensible. Because of the provider implementation, having a big
+# dict of values rather than named fields is not much more costly.
+# Design choice.  Replace data with actual providers, such as PackageInfo
+MetadataInfo = provider(
+    doc = """Generic bag of metadata.""",
+    fields = {
+        "type": "string: How to interpret data",
+        "label": "Label: label of the metadata rule",
+        "data": "String->any: Map of names to values",
+    }
+)
+
+TransitiveMetadataInfo = provider(
+    doc = """The transitive set of licenses used by a target.""",
+    fields = {
+        "top_level_target": "Label: The top level target label.",
+        "other_metadata": "depset(MetatdataInfo)",
+        "licenses": "depset(LicenseInfo)",
+        "package_info": "depset(PackageInfo)",
+
+        "target_under_license": "Label: The top level target label.",
+        "deps": "depset(LicensedTargetInfo): The transitive list of dependencies that have licenses.",
+        "traces": "list(string) - diagnostic for tracing a dependency relationship to a target.",
+    },
+)

--- a/rules/sbom.bzl
+++ b/rules/sbom.bzl
@@ -1,0 +1,159 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""SBOM generation"""
+
+load(
+    "@rules_license//rules:gather_metadata.bzl",
+    "gather_metadata_info",
+    "gather_metadata_info_and_write",
+    "write_metadata_info",
+)
+load(
+    "@rules_license//rules:providers.bzl",
+    "TransitiveLicensesInfo",
+)
+
+# This rule is proof of concept, and may not represent the final
+# form of a rule for compliance validation.
+def _generate_sbom_impl(ctx):
+    # Gather all licenses and write information to one place
+
+    licenses_file = ctx.actions.declare_file("_%s_licenses_info.json" % ctx.label.name)
+    write_metadata_info(ctx, ctx.attr.deps, licenses_file)
+
+    license_files = []
+    # if ctx.outputs.license_texts:
+    #     license_files = get_licenses_mapping(ctx.attr.deps).keys()
+
+    # Now turn the big blob of data into something consumable.
+    inputs = [licenses_file]
+    outputs = [ctx.outputs.out]
+    args = ctx.actions.args()
+    args.add("--licenses_info", licenses_file.path)
+    args.add("--out", ctx.outputs.out.path)
+    ctx.actions.run(
+        mnemonic = "CreateSBOM",
+        progress_message = "Creating SBOM for %s" % ctx.label,
+        inputs = inputs,
+        outputs = outputs,
+        executable = ctx.executable._sbom_generator,
+        arguments = [args],
+    )
+    outputs.append(licenses_file)  # also make the json file available.
+    return [DefaultInfo(files = depset(outputs))]
+
+_generate_sbom = rule(
+    implementation = _generate_sbom_impl,
+    attrs = {
+        "deps": attr.label_list(
+            aspects = [gather_metadata_info],
+        ),
+        "out": attr.output(mandatory = True),
+        "_sbom_generator": attr.label(
+            default = Label("@rules_license//tools:write_sbom"),
+            executable = True,
+            allow_files = True,
+            cfg = "exec",
+        ),
+    },
+)
+
+def generate_sbom(**kwargs):
+    _generate_sbom(**kwargs)
+
+def _manifest_impl(ctx):
+    # Gather all licenses and make it available as deps for downstream rules
+    # Additionally write the list of license filenames to a file that can
+    # also be used as an input to downstream rules.
+    licenses_file = ctx.actions.declare_file(ctx.attr.out.name)
+    mappings = get_licenses_mapping(ctx.attr.deps, ctx.attr.warn_on_legacy_licenses)
+    ctx.actions.write(
+        output = licenses_file,
+        content = "\n".join([",".join([f.path, p]) for (f, p) in mappings.items()]),
+    )
+    return [DefaultInfo(files = depset(mappings.keys()))]
+
+_manifest = rule(
+    implementation = _manifest_impl,
+    doc = """Internal tmplementation method for manifest().""",
+    attrs = {
+        "deps": attr.label_list(
+            doc = """List of targets to collect license files for.""",
+            aspects = [gather_metadata_info],
+        ),
+        "out": attr.output(
+            doc = """Output file.""",
+            mandatory = True,
+        ),
+        "warn_on_legacy_licenses": attr.bool(default = False),
+    },
+)
+
+def manifest(name, deps, out = None, **kwargs):
+    if not out:
+        out = name + ".manifest"
+
+    _manifest(name = name, deps = deps, out = out, **kwargs)
+
+def _licenses_used_impl(ctx):
+    # Gather all licenses and make it available as JSON
+    write_metadata_info(ctx, ctx.attr.deps, ctx.outputs.out)
+    return [DefaultInfo(files = depset([ctx.outputs.out]))]
+
+_licenses_used = rule(
+    implementation = _licenses_used_impl,
+    doc = """Internal tmplementation method for licenses_used().""",
+    attrs = {
+        "deps": attr.label_list(
+            doc = """List of targets to collect LicenseInfo for.""",
+            aspects = [gather_metadata_info_and_write],
+        ),
+        "out": attr.output(
+            doc = """Output file.""",
+            mandatory = True,
+        ),
+    },
+)
+
+def get_licenses_mapping(deps, warn = False):
+    """Creates list of entries representing all licenses for the deps.
+
+    Args:
+
+      deps: a list of deps which should have TransitiveLicensesInfo providers.
+            This requires that you have run the gather_licenses_info
+            aspect over them
+
+      warn: boolean, if true, display output about legacy targets that need
+            update
+
+    Returns:
+      {File:package_name}
+    """
+    tls = []
+    for dep in deps:
+        lds = dep[TransitiveLicensesInfo].licenses
+        tls.append(lds)
+
+    ds = depset(transitive = tls)
+
+    # Ignore any legacy licenses that may be in the report
+    mappings = {}
+    for lic in ds.to_list():
+        if type(lic.license_text) == "File":
+            mappings[lic.license_text] = lic.package_name
+        elif warn:
+            print("Legacy license %s not included, rule needs updating" % lic.license_text)
+
+    return mappings

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -15,7 +15,7 @@
 """License declaration and compliance checking tools."""
 
 package(
-    default_applicable_licenses = ["//:license"],
+    default_applicable_licenses = ["//:license", "//:package_info"],
     default_visibility = ["//visibility:public"],
 )
 

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -21,6 +21,14 @@ package(
 
 licenses(["notice"])
 
+filegroup(
+    name = "standard_package",
+    srcs = glob(["**"]),
+    visibility = ["//distro:__pkg__"],
+)
+
+exports_files(["diff_test.sh"])
+
 py_binary(
     name = "checker_demo",
     srcs = ["checker_demo.py"],
@@ -28,10 +36,9 @@ py_binary(
     visibility = ["//visibility:public"],
 )
 
-exports_files(["diff_test.sh"])
-
-filegroup(
-    name = "standard_package",
-    srcs = glob(["**"]),
-    visibility = ["//distro:__pkg__"],
+py_binary(
+    name = "write_sbom",
+    srcs = ["write_sbom.py"],
+    python_version = "PY3",
+    visibility = ["//visibility:public"],
 )

--- a/tools/write_sbom.py
+++ b/tools/write_sbom.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Proof of concept license checker.
+
+This is only a demonstration. It will be replaced with other tools.
+"""
+
+import argparse
+import codecs
+import datetime
+import json
+import os
+
+
+TOOL = 'https//github.com/bazelbuild/rules_license/tools:write_sbom'
+
+def _load_package_data(package_info):
+  with codecs.open(package_info, encoding='utf-8') as inp:
+    return json.loads(inp.read())
+
+def _write_sbom_header(out, package):
+  header = [
+    'SPDXVersion: SPDX-2.2',
+    'DataLicense: CC0-1.0',
+    'SPDXID: SPDXRef-DOCUMENT',
+    'DocumentName: %s' % package,
+    # TBD
+    # 'DocumentNamespace: https://swinslow.net/spdx-examples/example1/hello-v3
+    'Creator: Person: %s' % os.getlogin(),
+    'Creator: Tool: %s' % TOOL,
+    datetime.datetime.utcnow().strftime('Created: %Y-%m-%d-%H:%M:%SZ'),
+    '',
+    '##### Package: %s' % package,
+  ]
+  out.write('\n'.join(header))
+
+
+
+def _write_sbom(out, packages):
+  """Produce a basic SBOM
+
+  Args:
+    out: file object to write to
+    packages: package metadata. A big blob of JSON.
+  """
+  for p in packages:
+    name = p.get('package_name') or '<unknown>'
+    out.write('\n')
+    out.write('SPDXID: "%s"\n' % name)
+    out.write('  name: "%s"\n' % name)
+    if p.get('package_version'):
+      out.write('  versionInfo: "%s"\n' % p['package_version'])
+    # IGNORE_COPYRIGHT: Not a copyright notice. It is a variable holding one.
+    cn = p.get('copyright_notice')
+    if cn:
+      out.write('  copyrightText: "%s"\n' % cn)
+    kinds = p.get('license_kinds')
+    if kinds:
+      out.write('  licenseDeclared: "%s"\n' %
+                ','.join([k['name'] for k in kinds]))
+    url = p.get('package_url')
+    if url:
+      out.write('  downloadLocation: %s\n' % url)
+
+
+def main():
+  parser = argparse.ArgumentParser(
+      description='Demonstraton license compliance checker')
+
+  parser.add_argument('--licenses_info',
+                      help='path to JSON file containing all license data')
+  parser.add_argument('--out', default='sbom.out', help='SBOM output')
+  args = parser.parse_args()
+
+  license_data = _load_package_data(args.licenses_info)
+  target = license_data[0]  # we assume only one target for the demo
+
+  top_level_target = target['top_level_target']
+  dependencies = target['dependencies']
+  # It's not really packages, but this is close proxy for now
+  licenses = target['licenses']
+  package_infos = target['packages']
+
+  # These are similar dicts, so merge them by package. This is not
+  # strictly true, as different licenese can appear in the same
+  # package, but it is good enough for demonstrating the sbom.
+
+  all = {x['bazel_package']: x for x in licenses}
+  for pi in package_infos:
+    p = all.get(pi['bazel_package'])
+    if p:
+      p.update(pi)
+    else:
+      all[pi['bazel_package']] = pi
+
+  err = 0
+  with codecs.open(args.out, mode='w', encoding='utf-8') as out:
+    _write_sbom_header(out, package=top_level_target)
+    _write_sbom(out, all.values())
+  return err
+
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
Add package_info rule and a new gatherer to collect it.

- Add rules/package_info.bzl
- Refactor get_transitive_licenses to get_transitive_metadata.
  - Take a list of providers to gather.
  - Some hackery for Bazel 5.x support. This can be fixed if starlark visibility gets backported to Bazel 5.
- Add gather_metadata.bzl.  This is so we can freely experiment on techniques for multi provider support in OSS land, without impacting existing users in Google. We can merge them some day in the future.
- Create a dummy sbom writer.  It is just a PoC that we have enough data to dump. It must be replaced with something useful.

There is also experimental code to show a different design choice for new types of Metadata. I want to preserve both for a while to have a broader design discussion over the next month.

- [x] Tests pass
- [x] Tests and examples for any new features.
- [ ] Appropriate changes to README are included in PR
