### PR TITLE
Split providers.bzl in two.

### DIFF
--- a/examples/policy_checker/license_policy_check.bzl
+++ b/examples/policy_checker/license_policy_check.bzl
@@ -22,11 +22,8 @@ load(
     "@rules_license//rules:gather_licenses_info.bzl",
     "gather_licenses_info",
 )
-load(
-    "@rules_license//rules:providers.bzl",
-    "LicenseInfo",
-    "TransitiveLicensesInfo",
-)
+load("@rules_license//rules:providers.bzl", "LicenseInfo")
+load("@rules_license//rules:private/gathering_providers.bzl", "TransitiveLicensesInfo")
 
 # This is a crude example of the kind of thing which can be done.
 def _license_policy_check_impl(ctx):

--- a/rules/compliance.bzl
+++ b/rules/compliance.bzl
@@ -20,7 +20,7 @@ load(
     "write_licenses_info",
 )
 load(
-    "@rules_license//rules:providers.bzl",
+    "@rules_license//rules:private/gathering_providers.bzl",
     "TransitiveLicensesInfo",
 )
 

--- a/rules/gather_licenses_info.bzl
+++ b/rules/gather_licenses_info.bzl
@@ -20,7 +20,7 @@ load(
     "should_traverse",
 )
 load(
-    "@rules_license//rules:providers.bzl",
+    "@rules_license//rules:private/gathering_providers.bzl",
     "TransitiveLicensesInfo",
 )
 

--- a/rules/gather_metadata.bzl
+++ b/rules/gather_metadata.bzl
@@ -21,8 +21,11 @@ load(
 )
 load(
     "@rules_license//rules:providers.bzl",
-    "MetadataInfo",
+    "ExperimentalMetadataInfo",
     "PackageInfo",
+)
+load(
+    "@rules_license//rules:private/gathering_providers.bzl",
     "TransitiveMetadataInfo",
 )
 
@@ -47,7 +50,13 @@ def _bazel_package(label):
     return l[0:-(len(label.name) + 1)]
 
 def _gather_metadata_info_impl(target, ctx):
-    return gather_metadata_info_common(target, ctx, TransitiveMetadataInfo, NAMESPACES, [MetadataInfo, PackageInfo], should_traverse)
+    return gather_metadata_info_common(
+        target,
+        ctx,
+        TransitiveMetadataInfo,
+        NAMESPACES,
+        [ExperimentalMetadataInfo, PackageInfo],
+        should_traverse)
 
 gather_metadata_info = aspect(
     doc = """Collects LicenseInfo providers into a single TransitiveMetadataInfo provider.""",
@@ -283,7 +292,7 @@ def metadata_info_to_json(metadata_info):
                 package_url = mi.package_url,
                 package_version = mi.package_version,
             ))
-        # experimental: Support the MetadataInfo bag of data
+        # experimental: Support the ExperimentalMetadataInfo bag of data
         if mi.type == "package_info_alt":
             all_packages.append(package_info_template.format(
                 label = _strip_null_repo(mi.label),

--- a/rules/licenses_core.bzl
+++ b/rules/licenses_core.bzl
@@ -18,6 +18,9 @@ load("@rules_license//rules:user_filtered_rule_kinds.bzl", "user_aspect_filters"
 load(
     "@rules_license//rules:providers.bzl",
     "LicenseInfo",
+)
+load(
+    "@rules_license//rules:private/gathering_providers.bzl",
     "LicensedTargetInfo",
     "TransitiveLicensesInfo",
 )

--- a/rules/package_info.bzl
+++ b/rules/package_info.bzl
@@ -15,7 +15,7 @@
 
 load(
     "@rules_license//rules:providers.bzl",
-    "MetadataInfo",
+    "ExperimentalMetadataInfo",
     "PackageInfo",
 )
 
@@ -36,7 +36,7 @@ def _package_info_impl(ctx):
         package_version = ctx.attr.package_version,
     )
     # Experimental alternate design, using a generic 'data' back to hold things
-    generic_provider = MetadataInfo(
+    generic_provider = ExperimentalMetadataInfo(
         type = "package_info_alt",
         label = ctx.label,
         data = {

--- a/rules/private/gathering_providers.bzl
+++ b/rules/private/gathering_providers.bzl
@@ -1,0 +1,54 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Providers for transitively gathering all license and package_info targets.
+
+Warning: This is private to the aspect that walks the tree. The API is subject
+to change at any release.
+"""
+
+LicensedTargetInfo = provider(
+    doc = """Lists the licenses directly used by a single target.""",
+    fields = {
+        "target_under_license": "Label: The target label",
+        "licenses": "list(label of a license rule)",
+    },
+)
+
+def licenses_info():
+    return provider(
+        doc = """The transitive set of licenses used by a target.""",
+        fields = {
+            "target_under_license": "Label: The top level target label.",
+            "deps": "depset(LicensedTargetInfo): The transitive list of dependencies that have licenses.",
+            "licenses": "depset(LicenseInfo)",
+            "traces": "list(string) - diagnostic for tracing a dependency relationship to a target.",
+        },
+    )
+
+# This provider is used by the aspect that is used by manifest() rules.
+TransitiveLicensesInfo = licenses_info()
+
+TransitiveMetadataInfo = provider(
+    doc = """The transitive set of licenses used by a target.""",
+    fields = {
+        "top_level_target": "Label: The top level target label we are examining.",
+        "other_metadata": "depset(ExperimentalMetatdataInfo)",
+        "licenses": "depset(LicenseInfo)",
+        "package_info": "depset(PackageInfo)",
+
+        "target_under_license": "Label: A target which will be associated with some licenses.",
+        "deps": "depset(LicensedTargetInfo): The transitive list of dependencies that have licenses.",
+        "traces": "list(string) - diagnostic for tracing a dependency relationship to a target.",
+    },
+)

--- a/rules/providers.bzl
+++ b/rules/providers.bzl
@@ -11,7 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Providers for license rules."""
+"""Basic providers for license rules.
+
+This file should only contain the basic providers needed to create
+license and package_info declarations. Providers needed to gather
+them are declared in other places.
+"""
 
 LicenseKindInfo = provider(
     doc = """Provides information about a license_kind instance.""",
@@ -38,29 +43,6 @@ LicenseInfo = provider(
     },
 )
 
-LicensedTargetInfo = provider(
-    doc = """Lists the licenses directly used by a single target.""",
-    fields = {
-        "target_under_license": "Label: The target label",
-        "licenses": "list(label of a license rule)",
-    },
-)
-
-def licenses_info():
-    return provider(
-        doc = """The transitive set of licenses used by a target.""",
-        fields = {
-            "target_under_license": "Label: The top level target label.",
-            "deps": "depset(LicensedTargetInfo): The transitive list of dependencies that have licenses.",
-            "licenses": "depset(LicenseInfo)",
-            "traces": "list(string) - diagnostic for tracing a dependency relationship to a target.",
-        },
-    )
-
-# This provider is used by the aspect that is used by manifest() rules.
-TransitiveLicensesInfo = licenses_info()
-
-# This is one way to do specify data
 PackageInfo = provider(
     doc = """Provides information about a package.""",
     fields = {
@@ -75,25 +57,11 @@ PackageInfo = provider(
 # This is more extensible. Because of the provider implementation, having a big
 # dict of values rather than named fields is not much more costly.
 # Design choice.  Replace data with actual providers, such as PackageInfo
-MetadataInfo = provider(
+ExperimentalMetadataInfo = provider(
     doc = """Generic bag of metadata.""",
     fields = {
         "type": "string: How to interpret data",
         "label": "Label: label of the metadata rule",
         "data": "String->any: Map of names to values",
     }
-)
-
-TransitiveMetadataInfo = provider(
-    doc = """The transitive set of licenses used by a target.""",
-    fields = {
-        "top_level_target": "Label: The top level target label we are examining.",
-        "other_metadata": "depset(MetatdataInfo)",
-        "licenses": "depset(LicenseInfo)",
-        "package_info": "depset(PackageInfo)",
-
-        "target_under_license": "Label: A target which will be associated with some licenses.",
-        "deps": "depset(LicensedTargetInfo): The transitive list of dependencies that have licenses.",
-        "traces": "list(string) - diagnostic for tracing a dependency relationship to a target.",
-    },
 )

--- a/rules/sbom.bzl
+++ b/rules/sbom.bzl
@@ -20,7 +20,7 @@ load(
     "write_metadata_info",
 )
 load(
-    "@rules_license//rules:providers.bzl",
+    "@rules_license//rules:private/gathering_providers.bzl",
     "TransitiveLicensesInfo",
 )
 


### PR DESCRIPTION
- put all the core ones that are required to declare liceneses in providers.bzl
- move all the ones needed to gather licenses into private/gather_liceneses.bzl

This keeps ownership and visibility clearer. Users can depend on the values in provider.bzl.  The structs in gathering_providers.bzl should be considered private to the implementation.

Also, make it clear that MetadataInfo is experimental by renaming it.