### PR TITLE
gather_metadata_info and gather_licenses_info don't filter by license.namespace

### DIFF
--- a/rules/gather_licenses_info.bzl
+++ b/rules/gather_licenses_info.bzl
@@ -24,10 +24,6 @@ load(
     "TransitiveLicensesInfo",
 )
 
-# Definition for compliance namespace, used for filtering licenses
-# based on the namespace to which they belong.
-NAMESPACES = ["compliance"]
-
 def _strip_null_repo(label):
     """Removes the null repo name (e.g. @//) from a string.
 
@@ -41,7 +37,7 @@ def _strip_null_repo(label):
     return s
 
 def _gather_licenses_info_impl(target, ctx):
-    return gather_metadata_info_common(target, ctx, TransitiveLicensesInfo, NAMESPACES, [], should_traverse)
+    return gather_metadata_info_common(target, ctx, TransitiveLicensesInfo, [], should_traverse)
 
 gather_licenses_info = aspect(
     doc = """Collects LicenseInfo providers into a single TransitiveLicensesInfo provider.""",

--- a/rules/gather_metadata.bzl
+++ b/rules/gather_metadata.bzl
@@ -29,10 +29,6 @@ load(
     "TransitiveMetadataInfo",
 )
 
-# Definition for compliance namespace, used for filtering licenses
-# based on the namespace to which they belong.
-NAMESPACES = ["compliance"]
-
 def _strip_null_repo(label):
     """Removes the null repo name (e.g. @//) from a string.
 
@@ -54,7 +50,6 @@ def _gather_metadata_info_impl(target, ctx):
         target,
         ctx,
         TransitiveMetadataInfo,
-        NAMESPACES,
         [ExperimentalMetadataInfo, PackageInfo],
         should_traverse)
 

--- a/rules/licenses_core.bzl
+++ b/rules/licenses_core.bzl
@@ -113,7 +113,7 @@ def _get_transitive_metadata(ctx, trans_licenses, trans_other_metadata, trans_pa
                     if info.package_info:
                         trans_package_info.append(info.package_info)
 
-def gather_metadata_info_common(target, ctx, provider_factory, namespaces, metadata_providers, filter_func):
+def gather_metadata_info_common(target, ctx, provider_factory, metadata_providers, filter_func, namespaces=None):
     """Collect license and other metadata info from myself and my deps.
 
     Any single target might directly depend on a license, or depend on
@@ -132,9 +132,9 @@ def gather_metadata_info_common(target, ctx, provider_factory, namespaces, metad
       target: The target of the aspect.
       ctx: The aspect evaluation context.
       provider_factory: abstracts the provider returned by this aspect
-      namespaces: a list of namespaces licenses must match to be included
       metadata_providers: a list of other providers of interest
       filter_func: a function that returns true iff the dep edge should be ignored
+      namespaces: a list of namespaces licenses must match to be included
 
     Returns:
       provider of parameterized type
@@ -155,15 +155,14 @@ def gather_metadata_info_common(target, ctx, provider_factory, namespaces, metad
                 if LicenseInfo in dep:
                     lic = dep[LicenseInfo]
 
-                    # This check shouldn't be necessary since any license created
-                    # by the official code will have this set. However, one of the
-                    # tests has its own implementation of license that had to be fixed
-                    # so this is just a conservative safety check.
-                    if hasattr(lic, "namespace"):
-                        if lic.namespace in namespaces:
-                            licenses.append(lic)
+                    # Filter licenses by namespace iff `namespaces` is provided
+                    if namespaces:
+                        if hasattr(lic, "namespace"):
+                            if lic.namespace in namespaces:
+                                licenses.append(lic)
                     else:
-                        fail("should have a namespace")
+                        licenses.append(lic)
+
                 for m_p in metadata_providers:
                     if m_p in dep:
                         other_metadata.append(dep[m_p])

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -48,14 +48,6 @@ license(
     license_text = "LICENSE.extra",
 )
 
-# This license is not in the "compliance" namespace and
-# therefore should not show up in the report verified by
-# :verify_cc_app_test
-license(
-    name = "internal_non_compliance_license",
-    namespace = "test_namespace",
-)
-
 cc_binary(
     name = "hello",
     srcs = ["hello.cc"],
@@ -72,7 +64,6 @@ cc_library(
     applicable_licenses = [
         ":license",
         ":license_for_extra_feature",
-        ":internal_non_compliance_license",
     ],
     deps = [
         "@rules_license//tests/legacy:another_library_with_legacy_license_clause",


### PR DESCRIPTION
Fixes issue described [here](https://github.com/bazelbuild/rules_license/pull/53#discussion_r1091298529) in the comments of #53 

This change removed the requirement that `license`s be marked with `namespace = "compliance"` for the `gather_licenses_info` and `gather_metadata_info` aspects to include them in the providers the aspects return. Additionally, the `namespaces` parameters for `gather_metadata_info_common` is optional, and can be provided if a user wishes to filter `license`s by the `namespaces` attr. The test case for the old functionality was removed.

### Testing done
`bazel test tests/...` passes

