### PR TITLE
Allow license_text to be a normal label.

### DIFF
--- a/rules/license.bzl
+++ b/rules/license.bzl
@@ -24,6 +24,8 @@ load(
     "license_rule_impl",
 )
 
+_require_license_text_is_a_file = False
+
 _license = rule(
     implementation = license_rule_impl,
     attrs = {
@@ -34,6 +36,7 @@ _license = rule(
                   " should be listed here. If the user can choose a single one" +
                   " of many, then only list one here.",
             providers = [LicenseKindInfo],
+            # This should be the null configuration, not the exec.
             cfg = "exec",
         ),
         "copyright_notice": attr.string(
@@ -107,11 +110,12 @@ def license(
             fail("Can not use both license_kind and license_kinds")
         license_kinds = [license_kind]
 
-    # Make sure the file exists as named in the rule. A glob expression that
-    # expands to the name of the file is not acceptable.
-    srcs = native.glob([license_text])
-    if len(srcs) != 1 or srcs[0] != license_text:
-        fail("Specified license file doesn't exist: %s" % license_text)
+    if _require_license_text_is_a_file:
+        # Make sure the file exists as named in the rule. A glob expression that
+        # expands to the name of the file is not acceptable.
+        srcs = native.glob([license_text])
+        if len(srcs) != 1 or srcs[0] != license_text:
+            fail("Specified license file doesn't exist: %s" % license_text)
 
     _license(
         name = name,

--- a/rules/license.bzl
+++ b/rules/license.bzl
@@ -26,6 +26,10 @@ load(
 
 _require_license_text_is_a_file = False
 
+# This rule must be named "_license" for backwards compatability with older
+# or Bazel that checked that name explicitly. See
+# https://github.com/bazelbuild/bazel/commit/bbc221f60bc8c9177470529d85c3e47a5d9aaf21
+# TODO(after bazel 7.0 release): Feel free to rename the rule and move.
 _license = rule(
     implementation = license_rule_impl,
     attrs = {

--- a/rules/license.bzl
+++ b/rules/license.bzl
@@ -24,6 +24,8 @@ load(
     "license_rule_impl",
 )
 
+# Enable this if your organization requires the license text to be a file
+# checked into source control instead of, possibly, another rule.
 _require_license_text_is_a_file = False
 
 # This rule must be named "_license" for backwards compatability with older

--- a/rules/license_impl.bzl
+++ b/rules/license_impl.bzl
@@ -45,37 +45,3 @@ def license_rule_impl(ctx):
     )
     _debug(0, provider)
     return [provider]
-
-license_impl = rule(
-    implementation = license_rule_impl,
-    attrs = {
-        "license_kinds": attr.label_list(
-            mandatory = False,
-            doc = "License kind(s) of this license. If multiple license kinds are" +
-                  " listed in the LICENSE file, and they all apply, then all" +
-                  " should be listed here. If the user can choose a single one" +
-                  " of many, then only list one here.",
-            providers = [LicenseKindInfo],
-            cfg = "exec",
-        ),
-        "copyright_notice": attr.string(
-            doc = "Copyright notice.",
-        ),
-        "license_text": attr.label(
-            allow_single_file = True,
-            default = "LICENSE",
-            doc = "The license file.",
-        ),
-        "package_name": attr.string(
-            doc = "A human readable name identifying this package." +
-                  " This may be used to produce an index of OSS packages used by" +
-                  " an applicatation.",
-        ),
-        "namespace": attr.string(
-            doc = "A human readable name used to organize licenses into categories." +
-                  " This is used in google3 to differentiate third party licenses used" +
-                  " for compliance versus internal licenses used by SLAsan for internal" +
-                  " teams' SLAs.",
-        ),
-    },
-)

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -146,3 +146,17 @@ check_license(
         ":hello_java",
     ],
 )
+
+
+license(
+    name = "license_with_generated_text",
+    license_text = ":created_license",
+    license_kinds = [":generic_notice_license"],
+)
+
+genrule(
+    name = "created_license",
+    outs = ["something.text"],
+    cmd = "echo hello >$@",
+)
+


### PR DESCRIPTION
Make it easy for someone (who vendors the code) to enable the old behavior.

Fixes #68

RELNOTES: license_text can now refer to a label instead of being restricted to an existing file.


- [x] Tests pass
- [x] Tests and examples for any new features.
