### PR TITLE
Move TraceInfo to a new place

### DIFF
--- a/doc_build/BUILD
+++ b/doc_build/BUILD
@@ -59,6 +59,7 @@ ORDER = [
     ("LicenseInfo",     "//rules:providers.bzl"),
     ("LicenseKindInfo", "//rules:providers.bzl"),
     ("PackageInfo",     "//rules:providers.bzl"),
+    ("trace",           "//rules_gathering:trace.bzl"),
 ]
 
 genrule(
@@ -90,7 +91,7 @@ bzl_library(
         "//:version.bzl",
         "//rules:standard_package",
         "//rules/private:standard_package",
-        # "@bazel_skylib//lib:paths",
+        "//rules_gathering:standard_package",
     ],
     visibility = ["//visibility:public"],
 )

--- a/rules/gather_licenses_info.bzl
+++ b/rules/gather_licenses_info.bzl
@@ -15,7 +15,6 @@
 
 load(
     "@rules_license//rules:licenses_core.bzl",
-    "TraceInfo",
     "gather_metadata_info_common",
     "should_traverse",
 )
@@ -23,6 +22,7 @@ load(
     "@rules_license//rules/private:gathering_providers.bzl",
     "TransitiveLicensesInfo",
 )
+load("@rules_license//rules_gathering:trace.bzl", "TraceInfo")
 
 def _strip_null_repo(label):
     """Removes the null repo name (e.g. @//) from a string.

--- a/rules/gather_metadata.bzl
+++ b/rules/gather_metadata.bzl
@@ -15,7 +15,6 @@
 
 load(
     "@rules_license//rules:licenses_core.bzl",
-    "TraceInfo",
     "gather_metadata_info_common",
     "should_traverse",
 )
@@ -28,6 +27,7 @@ load(
     "@rules_license//rules/private:gathering_providers.bzl",
     "TransitiveMetadataInfo",
 )
+load("@rules_license//rules_gathering:trace.bzl", "TraceInfo")
 
 def _strip_null_repo(label):
     """Removes the null repo name (e.g. @//) from a string.

--- a/rules/licenses_core.bzl
+++ b/rules/licenses_core.bzl
@@ -14,33 +14,14 @@
 """Rules and macros for collecting LicenseInfo providers."""
 
 load("@rules_license//rules:filtered_rule_kinds.bzl", "aspect_filters")
+load("@rules_license//rules:providers.bzl", "LicenseInfo")
 load("@rules_license//rules:user_filtered_rule_kinds.bzl", "user_aspect_filters")
-load(
-    "@rules_license//rules:providers.bzl",
-    "LicenseInfo",
-)
 load(
     "@rules_license//rules/private:gathering_providers.bzl",
     "LicensedTargetInfo",
     "TransitiveLicensesInfo",
 )
-
-
-TraceInfo = provider(
-    doc = """Provides a target (as a string) to assist in debugging dependency issues.""",
-    fields = {
-        "trace": "String: a target to trace dependency edges to.",
-    },
-)
-
-def _trace_impl(ctx):
-    return TraceInfo(trace = ctx.build_setting_value)
-
-trace = rule(
-    doc = """Used to allow the specification of a target to trace while collecting license dependencies.""",
-    implementation = _trace_impl,
-    build_setting = config.string(flag = True),
-)
+load("@rules_license//rules_gathering:trace.bzl", "TraceInfo")
 
 def should_traverse(ctx, attr):
     """Checks if the dependent attribute should be traversed.

--- a/rules_gathering/BUILD
+++ b/rules_gathering/BUILD
@@ -1,6 +1,4 @@
-# BUILD file defining @rules_license/rules
-#
-# Copyright 2020 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,22 +13,9 @@
 # limitations under the License.
 """Rules for making license declarations."""
 
-load("@rules_license//rules_gathering:trace.bzl", "trace")
-
 package(
     default_applicable_licenses = ["//:license"],
     default_visibility = ["//visibility:public"],
-)
-
-licenses(["notice"])
-
-# This target controls the value of the traced target used during dependency collection.
-# This value should always be the empty string!
-# Specify this value with a flag, like --@rules_license//rules:trace_target=//target/to:trace
-trace(
-    name = "trace_target",
-    build_setting_default = "",  # TRACE-TARGET-SHOULD-BE-EMPTY
-    visibility = ["//visibility:public"],
 )
 
 filegroup(

--- a/rules_gathering/trace.bzl
+++ b/rules_gathering/trace.bzl
@@ -1,0 +1,30 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Rules and macros for collecting package metdata providers."""
+
+TraceInfo = provider(
+    doc = """Provides a target (as a string) to assist in debugging dependency issues.""",
+    fields = {
+        "trace": "String: a target to trace dependency edges to.",
+    },
+)
+
+def _trace_impl(ctx):
+    return TraceInfo(trace = ctx.build_setting_value)
+
+trace = rule(
+    doc = """Used to allow the specification of a target to trace while collecting license dependencies.""",
+    implementation = _trace_impl,
+    build_setting = config.string(flag = True),
+)


### PR DESCRIPTION
There are a few reasons for this:
- TraceInfo is a debugging hack internal to the metadata gathering rules. It does not belong with the broad facing rules. #85
- There is often a need for organizations to provide local implementations of gathering rules. Thus, we may have two copies of gather_metadata.bzl (and/or licenses_core.bzl) in our source tree.
- But having two distinct labels for a provider causes immense import pain.

Further cleanups to separate gather_* from `rules` to `rules_gathering` are coming.