### PR TITLE
Partial solution to #89.

### DIFF
--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -3,6 +3,7 @@ default_tests: &default_tests
   test_targets:
     - "//tests/..."
     - "//examples/..."
+    - "-//examples/manifest/..."
 
 #
 # Bazel releases

--- a/rules/licenses_core.bzl
+++ b/rules/licenses_core.bzl
@@ -147,6 +147,13 @@ def gather_metadata_info_common(target, ctx, provider_factory, metadata_provider
     trans_package_info = []
     trans_deps = []
     traces = []
+
+    # A hack until https://github.com/bazelbuild/rules_license/issues/89 is
+    # fully resolved. If exec is in the bin_dir path, then the current
+    # configuration is probably cfg = exec.
+    if "-exec-" in ctx.bin_dir.path:
+        return [provider_factory(deps = depset(), licenses = depset(), traces = [])]
+
     _get_transitive_metadata(ctx, trans_licenses, trans_other_metadata, trans_package_info, trans_deps, traces, provider_factory, filter_func)
 
     if not licenses and not trans_licenses:

--- a/rules/licenses_core.bzl
+++ b/rules/licenses_core.bzl
@@ -140,6 +140,12 @@ def gather_metadata_info_common(target, ctx, provider_factory, metadata_provider
                     if m_p in dep:
                         other_metadata.append(dep[m_p])
 
+    # A hack until https://github.com/bazelbuild/rules_license/issues/89 is
+    # fully resolved. If exec is in the bin_dir path, then the current
+    # configuration is probably cfg = exec.
+    if "-exec-" in ctx.bin_dir.path:
+        return [provider_factory(deps = depset(), licenses = depset(), traces = [])]
+
     # Now gather transitive collection of providers from the targets
     # this target depends upon.
     trans_licenses = []
@@ -147,12 +153,6 @@ def gather_metadata_info_common(target, ctx, provider_factory, metadata_provider
     trans_package_info = []
     trans_deps = []
     traces = []
-
-    # A hack until https://github.com/bazelbuild/rules_license/issues/89 is
-    # fully resolved. If exec is in the bin_dir path, then the current
-    # configuration is probably cfg = exec.
-    if "-exec-" in ctx.bin_dir.path:
-        return [provider_factory(deps = depset(), licenses = depset(), traces = [])]
 
     _get_transitive_metadata(ctx, trans_licenses, trans_other_metadata, trans_package_info, trans_deps, traces, provider_factory, filter_func)
 


### PR DESCRIPTION
While transitively gathering metadata:
- look at the bin.dir for any target we are traversing
- if it contains -exec it is probably in the exec configuration so skip it.

Part of #89 