### PR TITLE
Move licenses_used to sample_reports/licenses_used.bzl

### DIFF
--- a/examples/src/BUILD
+++ b/examples/src/BUILD
@@ -13,8 +13,9 @@
 # limitations under the License.
 # Examples of applications and interactions with licenses
 
-load("@rules_license//rules:compliance.bzl", "check_license", "licenses_used")
 load("@rules_license//examples/vndor/constant_gen:defs.bzl", "constant_gen")
+load("@rules_license//rules:compliance.bzl", "check_license")
+load("@rules_license//sample_reports:licenses_used.bzl", "licenses_used")
 
 package(
     default_package_metadata = ["//:license", "//:package_info"],

--- a/examples/vndor/constant_gen/BUILD
+++ b/examples/vndor/constant_gen/BUILD
@@ -13,8 +13,8 @@
 # limitations under the License.
 # An example of a code generator with a distinct license for the generated code.
 
-load("@rules_license//rules:compliance.bzl", "licenses_used")
 load("@rules_license//rules:license.bzl", "license")
+load("@rules_license//sample_reports:licenses_used.bzl", "licenses_used")
 load(":defs.bzl", "constant_gen")
 
 package(

--- a/rules/compliance.bzl
+++ b/rules/compliance.bzl
@@ -24,6 +24,14 @@ load(
     "TransitiveLicensesInfo",
 )
 
+# Forward licenses used until users migrate
+load(
+    "@rules_license//sample_reports:licenses_used.bzl",
+    _licenses_used = "licenses_used",
+)
+
+licenses_used = _licenses_used
+
 # This rule is proof of concept, and may not represent the final
 # form of a rule for compliance validation.
 def _check_license_impl(ctx):
@@ -119,26 +127,6 @@ def manifest(name, deps, out = None, **kwargs):
 
     _manifest(name = name, deps = deps, out = out, **kwargs)
 
-def _licenses_used_impl(ctx):
-    # Gather all licenses and make it available as JSON
-    write_licenses_info(ctx, ctx.attr.deps, ctx.outputs.out)
-    return [DefaultInfo(files = depset([ctx.outputs.out]))]
-
-_licenses_used = rule(
-    implementation = _licenses_used_impl,
-    doc = """Internal tmplementation method for licenses_used().""",
-    attrs = {
-        "deps": attr.label_list(
-            doc = """List of targets to collect LicenseInfo for.""",
-            aspects = [gather_licenses_info_and_write],
-        ),
-        "out": attr.output(
-            doc = """Output file.""",
-            mandatory = True,
-        ),
-    },
-)
-
 def get_licenses_mapping(deps, warn = False):
     """Creates list of entries representing all licenses for the deps.
 
@@ -170,28 +158,3 @@ def get_licenses_mapping(deps, warn = False):
             print("Legacy license %s not included, rule needs updating" % lic.license_text)
 
     return mappings
-
-def licenses_used(name, deps, out = None, **kwargs):
-    """Collects LicensedInfo providers for a set of targets and writes as JSON.
-
-    The output is a single JSON array, with an entry for each license used.
-    See gather_licenses_info.bzl:write_licenses_info() for a description of the schema.
-
-    Args:
-      name: The target.
-      deps: A list of targets to get LicenseInfo for. The output is the union of
-            the result, not a list of information for each dependency.
-      out: The output file name. Default: <name>.json.
-      **kwargs: Other args
-
-    Usage:
-
-      licenses_used(
-          name = "license_info",
-          deps = [":my_app"],
-          out = "license_info.json",
-      )
-    """
-    if not out:
-        out = name + ".json"
-    _licenses_used(name = name, deps = deps, out = out, **kwargs)

--- a/rules/compliance.bzl
+++ b/rules/compliance.bzl
@@ -24,7 +24,7 @@ load(
     "TransitiveLicensesInfo",
 )
 
-# Forward licenses used until users migrate
+# Forward licenses used until users migrate. Delete at 0.0.7 or 0.1.0.
 load(
     "@rules_license//sample_reports:licenses_used.bzl",
     _licenses_used = "licenses_used",

--- a/sample_reports/BUILD
+++ b/sample_reports/BUILD
@@ -1,0 +1,37 @@
+# BUILD file defining reference implementations for reporting tools
+#
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Rules for making license declarations."""
+
+package(
+    default_applicable_licenses = ["//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+licenses(["notice"])
+
+filegroup(
+    name = "standard_package",
+    srcs = glob(["**"]),
+)
+
+# Do not create a bzl_library(). That would create a dependency loop back
+# to bazel-skylib. We export the .bzl files to the documentation maker.
+exports_files(
+    glob([
+        "*.bzl",
+    ]),
+    visibility = ["//doc_build:__pkg__"],
+)

--- a/sample_reports/licenses_used.bzl
+++ b/sample_reports/licenses_used.bzl
@@ -1,0 +1,65 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""License compliance checking."""
+
+load(
+    "@rules_license//rules:gather_licenses_info.bzl",
+    "gather_licenses_info",
+    "write_licenses_info",
+)
+
+def _licenses_used_impl(ctx):
+    # Gather all licenses and make it available as JSON
+    write_licenses_info(ctx, ctx.attr.deps, ctx.outputs.out)
+    return [DefaultInfo(files = depset([ctx.outputs.out]))]
+
+_licenses_used = rule(
+    implementation = _licenses_used_impl,
+    doc = """Internal tmplementation method for licenses_used().""",
+    attrs = {
+        "deps": attr.label_list(
+            doc = """List of targets to collect LicenseInfo for.""",
+            aspects = [gather_licenses_info],
+        ),
+        "out": attr.output(
+            doc = """Output file.""",
+            mandatory = True,
+        ),
+    },
+)
+
+def licenses_used(name, deps, out = None, **kwargs):
+    """Collects LicensedInfo providers for a set of targets and writes as JSON.
+
+    The output is a single JSON array, with an entry for each license used.
+    See gather_licenses_info.bzl:write_licenses_info() for a description of the schema.
+
+    Args:
+      name: The target.
+      deps: A list of targets to get LicenseInfo for. The output is the union of
+            the result, not a list of information for each dependency.
+      out: The output file name. Default: <name>.json.
+      **kwargs: Other args
+
+    Usage:
+
+      licenses_used(
+          name = "license_info",
+          deps = [":my_app"],
+          out = "license_info.json",
+      )
+    """
+    if not out:
+        out = name + ".json"
+    _licenses_used(name = name, deps = deps, out = out, **kwargs)

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -1,8 +1,9 @@
 # Test cases for license rules.
 
-load("@rules_license//rules:compliance.bzl", "check_license", "licenses_used")
+load("@rules_license//rules:compliance.bzl", "check_license")
 load("@rules_license//rules:license.bzl", "license")
 load("@rules_license//rules:license_kind.bzl", "license_kind")
+load("@rules_license//sample_reports:licenses_used.bzl", "licenses_used")
 
 package(
     default_applicable_licenses = [":license"],

--- a/tests/apps/BUILD
+++ b/tests/apps/BUILD
@@ -1,6 +1,6 @@
 # Test cases for license rules: Sample app
 
-load("@rules_license//rules:compliance.bzl", "licenses_used")
+load("@rules_license//sample_reports:licenses_used.bzl", "licenses_used")
 
 package(default_visibility = ["//examples:__subpackages__"])
 


### PR DESCRIPTION
Move `licenses_used` from `rules/compliance.bzl` to `sample_reports/licenses_used.bzl`

`licenses_used` is really an example of how the rules can work. As such it is really to be used for examples and as a reference implementation for people to build their own reports from. 

`compliance.bzl` retains a forwarder which we can keep until 0.1.0 or 0.0.7

Bonus: Fix the rule so it does not do a double write.

Part of #85

- [X] Tests pass
- [N/A] Tests and examples for any new features.
- [N/A] Appropriate changes to README are included in PR
