### PR TITLE
Stop encouraging people to pull in an old python

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,14 +14,25 @@
 
 workspace(name = "rules_license")
 
-# You only need the dependencies if you intend to use any of the tools.
-load("@rules_license//:deps.bzl", "rules_license_dependencies")
-
-rules_license_dependencies()
-
+# rules_license has no dependencies for basic license and package_info
+# declarations.
+#
+# If you want to use any of the reporting or SBOM tools, and you are using a
+# WORKSPACE file instead of bzlmod, they you must explicitly depend on
+# rules_python in your WORKSPACE.
+ 
 ### INTERNAL ONLY - lines after this are not included in the release packaging.
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+   name = "rules_python",
+   sha256 = "ffc7b877c95413c82bfd5482c017edcf759a6250d8b24e82f41f3c8b8d9e287e",
+   strip_prefix = "rules_python-0.19.0",
+   urls = [
+       "https://github.com/bazelbuild/rules_python/releases/download/0.19.0/rules_python-0.19.0.tar.gz",
+   ],
+)
 
 http_archive(
     name = "rules_pkg",

--- a/deps.bzl
+++ b/deps.bzl
@@ -14,14 +14,5 @@
 
 """Workspace dependencies for rules_license/rules."""
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
-
 def rules_license_dependencies():
-    maybe(
-        http_archive,
-        name = "rules_python",
-        sha256 = "a30abdfc7126d497a7698c29c46ea9901c6392d6ed315171a6df5ce433aa4502",
-        strip_prefix = "rules_python-0.6.0",
-        url = "https://github.com/bazelbuild/rules_python/archive/0.6.0.tar.gz",
-    )
+    pass


### PR DESCRIPTION
More of #85 

This should complete enough of #85 to allow a 0.0.5 release. Then I can update Bazel to use that.

- [X] Tests pass
- [NA] Tests and examples for any new features.