### PR TITLE
Move rules/private/gathering_providers.bzl to rules_gathering

### DIFF
--- a/doc_build/BUILD
+++ b/doc_build/BUILD
@@ -90,7 +90,6 @@ bzl_library(
     srcs = [
         "//:version.bzl",
         "//rules:standard_package",
-        "//rules/private:standard_package",
         "//rules_gathering:standard_package",
     ],
     visibility = ["//visibility:public"],

--- a/examples/manifest/manifest.bzl
+++ b/examples/manifest/manifest.bzl
@@ -18,7 +18,7 @@ load(
     "gather_licenses_info",
 )
 load(
-    "@rules_license//rules/private:gathering_providers.bzl",
+    "@rules_license//rules_gathering:gathering_providers.bzl",
     "TransitiveLicensesInfo",
 )
 

--- a/examples/policy_checker/license_policy_check.bzl
+++ b/examples/policy_checker/license_policy_check.bzl
@@ -23,7 +23,7 @@ load(
     "gather_licenses_info",
 )
 load("@rules_license//rules:providers.bzl", "LicenseInfo")
-load("@rules_license//rules/private:gathering_providers.bzl", "TransitiveLicensesInfo")
+load("@rules_license//rules_gathering:gathering_providers.bzl", "TransitiveLicensesInfo")
 
 # This is a crude example of the kind of thing which can be done.
 def _license_policy_check_impl(ctx):

--- a/rules/compliance.bzl
+++ b/rules/compliance.bzl
@@ -20,7 +20,7 @@ load(
     "write_licenses_info",
 )
 load(
-    "@rules_license//rules/private:gathering_providers.bzl",
+    "@rules_license//rules_gathering:gathering_providers.bzl",
     "TransitiveLicensesInfo",
 )
 

--- a/rules/gather_licenses_info.bzl
+++ b/rules/gather_licenses_info.bzl
@@ -19,7 +19,7 @@ load(
     "should_traverse",
 )
 load(
-    "@rules_license//rules/private:gathering_providers.bzl",
+    "@rules_license//rules_gathering:gathering_providers.bzl",
     "TransitiveLicensesInfo",
 )
 load("@rules_license//rules_gathering:trace.bzl", "TraceInfo")

--- a/rules/licenses_core.bzl
+++ b/rules/licenses_core.bzl
@@ -17,7 +17,7 @@ load("@rules_license//rules:filtered_rule_kinds.bzl", "aspect_filters")
 load("@rules_license//rules:providers.bzl", "LicenseInfo")
 load("@rules_license//rules:user_filtered_rule_kinds.bzl", "user_aspect_filters")
 load(
-    "@rules_license//rules/private:gathering_providers.bzl",
+    "@rules_license//rules_gathering:gathering_providers.bzl",
     "LicensedTargetInfo",
     "TransitiveLicensesInfo",
 )

--- a/rules/private/gathering_providers.bzl
+++ b/rules/private/gathering_providers.bzl
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,44 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Providers for transitively gathering all license and package_info targets.
+"""Temporary forwarder.
 
-Warning: This is private to the aspect that walks the tree. The API is subject
-to change at any release.
+TODO(2023-07-01): Delete this file.
 """
 
-LicensedTargetInfo = provider(
-    doc = """Lists the licenses directly used by a single target.""",
-    fields = {
-        "target_under_license": "Label: The target label",
-        "licenses": "list(label of a license rule)",
-    },
+load(
+    "@rules_license//rules_gathering:gathering_providers.bzl",
+    _private_TransitiveLicensesInfo = "TransitiveLicensesInfo",
 )
 
-def licenses_info():
-    return provider(
-        doc = """The transitive set of licenses used by a target.""",
-        fields = {
-            "target_under_license": "Label: The top level target label.",
-            "deps": "depset(LicensedTargetInfo): The transitive list of dependencies that have licenses.",
-            "licenses": "depset(LicenseInfo)",
-            "traces": "list(string) - diagnostic for tracing a dependency relationship to a target.",
-        },
-    )
-
-# This provider is used by the aspect that is used by manifest() rules.
-TransitiveLicensesInfo = licenses_info()
-
-TransitiveMetadataInfo = provider(
-    doc = """The transitive set of licenses used by a target.""",
-    fields = {
-        "top_level_target": "Label: The top level target label we are examining.",
-        "other_metadata": "depset(ExperimentalMetatdataInfo)",
-        "licenses": "depset(LicenseInfo)",
-        "package_info": "depset(PackageInfo)",
-
-        "target_under_license": "Label: A target which will be associated with some licenses.",
-        "deps": "depset(LicensedTargetInfo): The transitive list of dependencies that have licenses.",
-        "traces": "list(string) - diagnostic for tracing a dependency relationship to a target.",
-    },
-)
+TransitiveLicensesInfo = _private_TransitiveLicensesInfo

--- a/rules/providers.bzl
+++ b/rules/providers.bzl
@@ -19,7 +19,7 @@ them are declared in other places.
 """
 
 load(
-    "@rules_license//rules/private:gathering_providers.bzl",
+    "@rules_license//rules_gathering:gathering_providers.bzl",
     _private_TransitiveLicensesInfo = "TransitiveLicensesInfo",
 )
 

--- a/rules_gathering/gather_metadata.bzl
+++ b/rules_gathering/gather_metadata.bzl
@@ -24,7 +24,7 @@ load(
     "PackageInfo",
 )
 load(
-    "@rules_license//rules/private:gathering_providers.bzl",
+    "@rules_license//rules_gathering:gathering_providers.bzl",
     "TransitiveMetadataInfo",
 )
 load("@rules_license//rules_gathering:trace.bzl", "TraceInfo")

--- a/rules_gathering/gathering_providers.bzl
+++ b/rules_gathering/gathering_providers.bzl
@@ -1,0 +1,54 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Providers for transitively gathering all license and package_info targets.
+
+Warning: This is private to the aspect that walks the tree. The API is subject
+to change at any release.
+"""
+
+LicensedTargetInfo = provider(
+    doc = """Lists the licenses directly used by a single target.""",
+    fields = {
+        "target_under_license": "Label: The target label",
+        "licenses": "list(label of a license rule)",
+    },
+)
+
+def licenses_info():
+    return provider(
+        doc = """The transitive set of licenses used by a target.""",
+        fields = {
+            "target_under_license": "Label: The top level target label.",
+            "deps": "depset(LicensedTargetInfo): The transitive list of dependencies that have licenses.",
+            "licenses": "depset(LicenseInfo)",
+            "traces": "list(string) - diagnostic for tracing a dependency relationship to a target.",
+        },
+    )
+
+# This provider is used by the aspect that is used by manifest() rules.
+TransitiveLicensesInfo = licenses_info()
+
+TransitiveMetadataInfo = provider(
+    doc = """The transitive set of licenses used by a target.""",
+    fields = {
+        "top_level_target": "Label: The top level target label we are examining.",
+        "other_metadata": "depset(ExperimentalMetatdataInfo)",
+        "licenses": "depset(LicenseInfo)",
+        "package_info": "depset(PackageInfo)",
+
+        "target_under_license": "Label: A target which will be associated with some licenses.",
+        "deps": "depset(LicensedTargetInfo): The transitive list of dependencies that have licenses.",
+        "traces": "list(string) - diagnostic for tracing a dependency relationship to a target.",
+    },
+)

--- a/rules_gathering/generate_sbom.bzl
+++ b/rules_gathering/generate_sbom.bzl
@@ -20,7 +20,7 @@ load(
     "write_metadata_info",
 )
 load(
-    "@rules_license//rules/private:gathering_providers.bzl",
+    "@rules_license//rules_gathering:gathering_providers.bzl",
     "TransitiveLicensesInfo",
 )
 


### PR DESCRIPTION
Move rules/private/gathering_providers.bzl to rules_gathering/gatheri…ng_providers.bzl

- They should not have been in basic rules/...
- buildifier keeps complaining about accesing things from private (ain't no 'friends' classes in bazel)
- Leave a temporary forwarder

For  #85
