### PR TITLE
Prefer getpass.getuser() over os.getlogin()

### DIFF
--- a/tools/write_sbom.py
+++ b/tools/write_sbom.py
@@ -21,8 +21,8 @@ This is only a demonstration. It will be replaced with other tools.
 import argparse
 import codecs
 import datetime
+import getpass
 import json
-import os
 
 
 TOOL = 'https//github.com/bazelbuild/rules_license/tools:write_sbom'
@@ -39,7 +39,7 @@ def _write_sbom_header(out, package):
     'DocumentName: %s' % package,
     # TBD
     # 'DocumentNamespace: https://swinslow.net/spdx-examples/example1/hello-v3
-    'Creator: Person: %s' % os.getlogin(),
+    'Creator: Person: %s' % getpass.getuser(),
     'Creator: Tool: %s' % TOOL,
     datetime.datetime.utcnow().strftime('Created: %Y-%m-%d-%H:%M:%SZ'),
     '',


### PR DESCRIPTION
Prefer getpass.getuser() over os.getlogin() as noted in the [official docs](https://docs.python.org/3/library/os.html#os.getlogin).

This fixes the following error when running within a Debian container in GitHub codespaces:
```
>>> import os
>>> os.getlogin()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
OSError: [Errno 6] No such device or address
```

- [ ] Tests pass
- [ ] Tests and examples for any new features.
- [ ] Appropriate changes to README are included in PR
