### PR TITLE
Change target to targets for license_policy_check

### DIFF
--- a/examples/policy_checker/BUILD
+++ b/examples/policy_checker/BUILD
@@ -47,7 +47,7 @@ license_policy(
 license_policy_check(
     name = "check_server",
     policy = ":production_service",
-    target = "//examples/src:my_server",
+    targets = ["//examples/src:my_server"],
 )
 
 
@@ -59,5 +59,5 @@ license_policy_check(
     tags = [
         "manual",
     ],
-    target = "//examples/src:my_violating_server",
+    targets = ["//examples/src:my_violating_server"],
 )

--- a/examples/policy_checker/license_policy_check.bzl
+++ b/examples/policy_checker/license_policy_check.bzl
@@ -25,31 +25,34 @@ load(
 load("@rules_license//rules:providers.bzl", "LicenseInfo")
 load("@rules_license//rules_gathering:gathering_providers.bzl", "TransitiveLicensesInfo")
 
-# This is a crude example of the kind of thing which can be done.
+# This is a crude example of the kind of license reporting which can be done.
 def _license_policy_check_impl(ctx):
     policy = ctx.attr.policy[LicensePolicyInfo]
     allowed_conditions = policy.conditions
-    if TransitiveLicensesInfo in ctx.attr.target:
-        for license in ctx.attr.target[TransitiveLicensesInfo].licenses.to_list():
-            for kind in license.license_kinds:
-                # print(kind.conditions)
-                for condition in kind.conditions:
-                    if condition not in allowed_conditions:
-                        fail("Condition %s violates policy %s" % (
-                            condition,
-                            policy.label,
-                        ))
 
-    if LicenseInfo in ctx.attr.target:
-        for license in ctx.attr.target[LicenseInfo].licenses.to_list():
-            for kind in license.license_kinds:
-                # print(kind.conditions)
-                for condition in kind.conditions:
-                    if condition not in allowed_conditions:
-                        fail("Condition %s violates policy %s" % (
-                            condition,
-                            policy.label,
-                        ))
+    for target in ctx.attr.targets:
+        if TransitiveLicensesInfo in target:
+            for license in target[TransitiveLicensesInfo].licenses.to_list():
+                for kind in license.license_kinds:
+                    for condition in kind.conditions:
+                        if condition not in allowed_conditions:
+                            fail("Condition %s violates policy %s of %s" % (
+                                condition,
+                                policy.label,
+                                target.label,
+                            ))
+
+    for target in ctx.attr.targets:
+        if LicenseInfo in target:
+            for license in target[LicenseInfo].licenses.to_list():
+                for kind in license.license_kinds:
+                    for condition in kind.conditions:
+                        if condition not in allowed_conditions:
+                            fail("Condition %s violates policy %s of %s" % (
+                                condition,
+                                policy.label,
+                                target.label,
+                            ))
     return [DefaultInfo()]
 
 _license_policy_check = rule(
@@ -61,21 +64,20 @@ _license_policy_check = rule(
             mandatory = True,
             providers = [LicensePolicyInfo],
         ),
-        "target": attr.label(
+        "targets": attr.label_list(
             doc = """Target to collect LicenseInfo for.""",
             aspects = [gather_licenses_info],
             mandatory = True,
-            allow_single_file = True,
         ),
     },
 )
 
-def license_policy_check(name, target, policy, **kwargs):
-    """Checks a target against a policy.
+def license_policy_check(name, targets, policy, **kwargs):
+    """Checks a list of targets against a policy.
 
     Args:
       name: The target.
-      target: A target to test for compliance with a policy
+      targets: A list of targets to test for compliance with a policy
       policy: A rule providing LicensePolicyInfo.
       **kwargs: other args.
 
@@ -83,8 +85,8 @@ def license_policy_check(name, target, policy, **kwargs):
 
       license_policy_check(
           name = "license_info",
-          target = ":my_app",
+          targets = [":my_app"],
           policy = "//my_org/compliance/policies:mobile_application",
       )
     """
-    _license_policy_check(name = name, target = target, policy = policy, **kwargs)
+    _license_policy_check(name = name, targets = targets, policy = policy, **kwargs)


### PR DESCRIPTION
When `license_policy_check` is applied to a target that generates multiple files, the policy check fails. See below for an example error message.
```
in target attribute of _license_policy_check rule <:label_for_target_policy_check_is_applied_to> must produce a single file.
```
This seems to be due to `allow_single_file = True` in the description of the rule's attr `target`. This change removes the line, allowing a policy check to be applied to targets producing multiple files or a single file.

This change was tested by applying `license_policy_check` to a `java_binary` target (producing 2 files) and a `java_library` target (producing 1 file). Both policy checks ran successfully.

Cloned from #71.
Fixes #71