### PR TITLE
Move licenses_file to separate output group

### DIFF
--- a/examples/sboms/BUILD
+++ b/examples/sboms/BUILD
@@ -7,7 +7,7 @@ load("@rules_license//rules_gathering:generate_sbom.bzl", "generate_sbom")
 # which generates the SBOMs
 # See the output in bazel-bin/examples/sboms/write_sbom.txt
 generate_sbom(
-    name = "write_sbom_sbom",
+    name = "write_sbom",
     out = "write_sbom.txt",
     deps = ["//tools:write_sbom"],
 )

--- a/rules/compliance.bzl
+++ b/rules/compliance.bzl
@@ -67,8 +67,10 @@ def _check_license_impl(ctx):
         executable = ctx.executable._checker,
         arguments = [args],
     )
-    outputs.append(licenses_file)  # also make the json file available.
-    return [DefaultInfo(files = depset(outputs))]
+    return [
+        DefaultInfo(files = depset(outputs)),
+        OutputGroupInfo(licenses_file = depset([licenses_file])),
+    ]
 
 _check_license = rule(
     implementation = _check_license_impl,

--- a/rules_gathering/generate_sbom.bzl
+++ b/rules_gathering/generate_sbom.bzl
@@ -46,8 +46,10 @@ def _generate_sbom_impl(ctx):
         executable = ctx.executable._sbom_generator,
         arguments = [args],
     )
-    outputs.append(licenses_file)  # also make the json file available.
-    return [DefaultInfo(files = depset(outputs))]
+    return [
+        DefaultInfo(files = depset(outputs)),
+        OutputGroupInfo(licenses_file = depset([licenses_file])),
+    ]
 
 _generate_sbom = rule(
     implementation = _generate_sbom_impl,


### PR DESCRIPTION
When packaging outputs via rules_pkg we should not include the licenses_file by default. To avoid that, move it to its own output group.

With this change:
bazel cquery --output=files //examples/sboms:write_sbom 2> /dev/null && \ bazel cquery --output=files //examples/src:check_server 2> /dev/null bazel-out/darwin-fastbuild/bin/examples/sboms/write_sbom.txt bazel-out/darwin-fastbuild/bin/examples/src/server_report.txt bazel-out/darwin-fastbuild/bin/examples/src/server_licenses.txt

Before this change those commands would include:
bazel-out/darwin-fastbuild/bin/examples/sboms/_write_sbom_sbom_licenses_info.json bazel-out/darwin-fastbuild/bin/examples/src/_check_server_licenses_info.json

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Tests and examples for any new features.
- [ ] Appropriate changes to README are included in PR
