### PR TITLE
chore: create pre-commit file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+# See CONTRIBUTING.md for instructions.
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+
+repos:
+  # Check formatting and lint for starlark code
+  - repo: https://github.com/keith/pre-commit-buildifier
+    rev: 6.3.3
+    hooks:
+      - id: buildifier
+        args: ["-mode=fix", "-lint=fix"]
+      - id: buildifier-lint

--- a/BUILD
+++ b/BUILD
@@ -12,12 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_license//:version.bzl", "version")
 load("@rules_license//rules:license.bzl", "license")
 load("@rules_license//rules:package_info.bzl", "package_info")
-load("@rules_license//:version.bzl", "version")
 
 package(
-    default_applicable_licenses = [":license", ":package_info"],
+    default_applicable_licenses = [
+        ":license",
+        ":package_info",
+    ],
     default_visibility = ["//visibility:public"],
 )
 
@@ -38,7 +41,10 @@ package_info(
 )
 
 exports_files(
-    ["LICENSE", "WORKSPACE"],
+    [
+        "LICENSE",
+        "WORKSPACE",
+    ],
     visibility = ["//visibility:public"],
 )
 
@@ -55,9 +61,9 @@ filegroup(
         "*.bzl",
         "*.md",
     ]) + [
-        "MODULE.bazel",
         "BUILD",
         "LICENSE",
+        "MODULE.bazel",
         "WORKSPACE.bzlmod",
     ],
     visibility = ["//distro:__pkg__"],

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -20,27 +20,27 @@ workspace(name = "rules_license")
 # If you want to use any of the reporting or SBOM tools, and you are using a
 # WORKSPACE file instead of bzlmod, they you must explicitly depend on
 # rules_python in your WORKSPACE.
- 
+
 ### INTERNAL ONLY - lines after this are not included in the release packaging.
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
-   name = "rules_python",
-   sha256 = "ffc7b877c95413c82bfd5482c017edcf759a6250d8b24e82f41f3c8b8d9e287e",
-   strip_prefix = "rules_python-0.19.0",
-   urls = [
-       "https://github.com/bazelbuild/rules_python/releases/download/0.19.0/rules_python-0.19.0.tar.gz",
-   ],
+    name = "rules_python",
+    sha256 = "ffc7b877c95413c82bfd5482c017edcf759a6250d8b24e82f41f3c8b8d9e287e",
+    strip_prefix = "rules_python-0.19.0",
+    urls = [
+        "https://github.com/bazelbuild/rules_python/releases/download/0.19.0/rules_python-0.19.0.tar.gz",
+    ],
 )
 
 http_archive(
     name = "rules_pkg",
+    sha256 = "eea0f59c28a9241156a47d7a8e32db9122f3d50b505fae0f33de6ce4d9b61834",
     urls = [
         "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.8.0/rules_pkg-0.8.0.tar.gz",
         "https://github.com/bazelbuild/rules_pkg/releases/download/0.8.0/rules_pkg-0.8.0.tar.gz",
     ],
-    sha256 = "eea0f59c28a9241156a47d7a8e32db9122f3d50b505fae0f33de6ce4d9b61834",
 )
 
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")

--- a/distro/BUILD
+++ b/distro/BUILD
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//:version.bzl", "version")
 load("@rules_pkg//pkg:pkg.bzl", "pkg_tar")
 load("@rules_pkg//pkg/releasing:defs.bzl", "print_rel_notes")
+load("//:version.bzl", "version")
 
 package(
-    default_visibility = ["//visibility:public"],
     default_applicable_licenses = ["//:license"],
+    default_visibility = ["//visibility:public"],
 )
 
 licenses(["notice"])
@@ -37,8 +37,8 @@ pkg_tar(
         "//licenses/generic:standard_package",
         "//licenses/spdx:standard_package",
         "//rules:standard_package",
-        "//rules_gathering:standard_package",
         "//rules/private:standard_package",
+        "//rules_gathering:standard_package",
         "//sample_reports:standard_package",
         "//tools:standard_package",
     ],

--- a/doc_build/BUILD
+++ b/doc_build/BUILD
@@ -21,10 +21,11 @@ How to:
 
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@io_bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
-load("@rules_python//python:defs.bzl", "py_library")
-load("//:version.bzl", "version")
 
-package(default_package_metadata = ["//:license", "//:package_info"])
+package(default_package_metadata = [
+    "//:license",
+    "//:package_info",
+])
 
 filegroup(
     name = "standard_package",
@@ -50,18 +51,18 @@ exports_files(
 # Must put macro wrapped rules after their wrapper
 # buildifier: leave-alone, do not sort
 ORDER = [
-    ("license",         "//rules:license.bzl"),
-    ("_license",        "//rules:license.bzl"),
-    ("license_kind",    "//rules:license_kind.bzl"),
-    ("_license_kind",   "//rules:license_kind.bzl"),
-    ("package_info",    "//rules:package_info.bzl"),
-    ("_package_info",   "//rules:package_info.bzl"),
-    ("LicenseInfo",     "//rules:providers.bzl"),
+    ("license", "//rules:license.bzl"),
+    ("_license", "//rules:license.bzl"),
+    ("license_kind", "//rules:license_kind.bzl"),
+    ("_license_kind", "//rules:license_kind.bzl"),
+    ("package_info", "//rules:package_info.bzl"),
+    ("_package_info", "//rules:package_info.bzl"),
+    ("LicenseInfo", "//rules:providers.bzl"),
     ("LicenseKindInfo", "//rules:providers.bzl"),
-    ("PackageInfo",     "//rules:providers.bzl"),
-    ("gather_metadata_info",           "//rules_gathering:gather_metadata.bzl"),
+    ("PackageInfo", "//rules:providers.bzl"),
+    ("gather_metadata_info", "//rules_gathering:gather_metadata.bzl"),
     ("gather_metadata_info_and_write", "//rules_gathering:gather_metadata.bzl"),
-    ("trace",           "//rules_gathering:trace.bzl"),
+    ("trace", "//rules_gathering:trace.bzl"),
 ]
 
 genrule(

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -31,3 +31,9 @@ implementation.
 
 This project follows
 [Google's Open Source Community Guidelines](https://opensource.google/conduct/).
+
+## Formatting and linting
+
+We recommend that you install [pre-commit](https://pre-commit.com) so that your code is automatically
+formatted when you `git commit`.
+We may enforce that code is formatted and/or lint-free in our CI at some point.

--- a/examples/manifest/BUILD
+++ b/examples/manifest/BUILD
@@ -1,6 +1,5 @@
-load(":android_mock.bzl", "android_binary", "android_library")
 load("@rules_license//tools:test_helpers.bzl", "golden_cmd_test")
-
+load(":android_mock.bzl", "android_binary", "android_library")
 
 # These two rules today capture what an android_binary would look like.
 # This rule represents the Android specific code that displays licenses
@@ -13,7 +12,7 @@ android_library(
         "license_display.sh",
     ],
     data = [
-      "@rules_license//distro:distro",
+        "@rules_license//distro",
     ],
 )
 
@@ -25,10 +24,10 @@ android_library(
 android_binary(
     name = "main",
     srcs = ["main.sh"],
-    deps = [
-    ],
     data = [
         ":licenses",
+    ],
+    deps = [
     ],
 )
 
@@ -36,6 +35,6 @@ golden_cmd_test(
     name = "main_test",
     srcs = [],
     cmd = "$(location :main)",
-    tools = [":main"],
     golden = "main_golden.txt",
+    tools = [":main"],
 )

--- a/examples/manifest/android_mock.bzl
+++ b/examples/manifest/android_mock.bzl
@@ -1,9 +1,9 @@
-load("manifest.bzl", "manifest")
-
 """This is a proof of concept to show how to modify a macro definition to
 create a sub-graph allowing for build time injection of license information. We
 use Android-inspired rule names since these are a likely candidate for this
 sort of injection."""
+
+load("manifest.bzl", "manifest")
 
 def android_library(name, **kwargs):
     # This is an approximation for demo purposes.
@@ -21,6 +21,7 @@ def android_library(name, **kwargs):
         **kwargs
     )
 
+# buildifier: disable=function-docstring
 def android_binary(name, **kwargs):
     # Same observation about not being sloppy with mapping deps, but I think the only important attribute
     # in android_binary is deps, but need to double-check.

--- a/examples/manifest/manifest.bzl
+++ b/examples/manifest/manifest.bzl
@@ -50,9 +50,9 @@ def get_licenses_mapping(deps, warn = False):
         if type(lic.license_text) == "File":
             mappings[lic.license_text] = lic.package_name
         elif warn:
+            # buildifier: disable=print
             print("Legacy license %s not included, rule needs updating" % lic.license_text)
     return mappings
-
 
 def _manifest_impl(ctx):
     # Gather all licenses and make it available as deps for downstream rules
@@ -86,4 +86,3 @@ def manifest(name, deps, out = None, **kwargs):
     if not out:
         out = name + ".manifest"
     _manifest(name = name, deps = deps, out = out, **kwargs)
-

--- a/examples/policy_checker/BUILD
+++ b/examples/policy_checker/BUILD
@@ -3,7 +3,10 @@
 load("@rules_license//examples/policy_checker:license_policy.bzl", "license_policy")
 load("@rules_license//examples/policy_checker:license_policy_check.bzl", "license_policy_check")
 
-package(default_package_metadata = ["//:license", "//:package_info"])
+package(default_package_metadata = [
+    "//:license",
+    "//:package_info",
+])
 
 # license_policy rules generally appear in a central location per workspace. That
 # should be access controlled by the policy team.
@@ -49,7 +52,6 @@ license_policy_check(
     policy = ":production_service",
     targets = ["//examples/src:my_server"],
 )
-
 
 # This is marked manual, so bazel test ... does not fail. Try it yourself with
 #   bazel build :check_violating_server

--- a/examples/policy_checker/license_policy.bzl
+++ b/examples/policy_checker/license_policy.bzl
@@ -22,7 +22,7 @@ application type (e.g. production_server, mobile_application, ...)
 
 load(
     "@rules_license//examples/policy_checker:license_policy_provider.bzl",
-    "LicensePolicyInfo"
+    "LicensePolicyInfo",
 )
 
 def _license_policy_impl(ctx):

--- a/examples/src/BUILD
+++ b/examples/src/BUILD
@@ -18,7 +18,10 @@ load("@rules_license//rules:compliance.bzl", "check_license")
 load("@rules_license//sample_reports:licenses_used.bzl", "licenses_used")
 
 package(
-    default_package_metadata = ["//:license", "//:package_info"],
+    default_package_metadata = [
+        "//:license",
+        "//:package_info",
+    ],
     default_visibility = ["//examples:__subpackages__"],
 )
 

--- a/examples/vndor/acme/BUILD
+++ b/examples/vndor/acme/BUILD
@@ -16,8 +16,8 @@
 load("@rules_license//rules:license.bzl", "license")
 
 package(
-   default_applicable_licenses = [":license"],
-   default_visibility = ["//examples:__subpackages__"],
+    default_applicable_licenses = [":license"],
+    default_visibility = ["//examples:__subpackages__"],
 )
 
 # The default license for an entire package is typically named "license".

--- a/examples/vndor/constant_gen/BUILD
+++ b/examples/vndor/constant_gen/BUILD
@@ -72,8 +72,8 @@ py_test(
     name = "verify_licenses_test",
     srcs = ["verify_licenses_test.py"],
     data = [
-        ":generator_licenses.json",
         ":generated_code_licenses.json",
+        ":generator_licenses.json",
     ],
     python_version = "PY3",
     deps = [

--- a/rules/check_licenses_shim.bzl
+++ b/rules/check_licenses_shim.bzl
@@ -14,7 +14,7 @@
 """This module provides a custom Starlark rule used to create wrappers for targets that
 can have blaze build --check_licenses executed against them."""
 
-def _shim_rule_impl(ctx):
+def _shim_rule_impl(_):
     # This rule doesn't need to return anything. It only exists to propagate the dependency supplied
     # by the label_flag
     return []

--- a/rules/compliance.bzl
+++ b/rules/compliance.bzl
@@ -16,7 +16,6 @@
 load(
     "@rules_license//rules:gather_licenses_info.bzl",
     "gather_licenses_info",
-    "gather_licenses_info_and_write",
     "write_licenses_info",
 )
 load(
@@ -157,6 +156,7 @@ def get_licenses_mapping(deps, warn = False):
         if type(lic.license_text) == "File":
             mappings[lic.license_text] = lic.package_name
         elif warn:
+            # buildifier: disable=print
             print("Legacy license %s not included, rule needs updating" % lic.license_text)
 
     return mappings

--- a/rules/gather_licenses_info.bzl
+++ b/rules/gather_licenses_info.bzl
@@ -30,9 +30,9 @@ def _strip_null_repo(label):
     The is to make str(label) compatible between bazel 5.x and 6.x
     """
     s = str(label)
-    if s.startswith('@//'):
+    if s.startswith("@//"):
         return s[1:]
-    elif s.startswith('@@//'):
+    elif s.startswith("@@//"):
         return s[2:]
     return s
 
@@ -150,7 +150,7 @@ def write_licenses_info(ctx, deps, json_out):
     licenses_files = []
     for dep in deps:
         if TransitiveLicensesInfo in dep:
-            transitive_licenses_info = dep[TransitiveLicensesInfo]            
+            transitive_licenses_info = dep[TransitiveLicensesInfo]
             lic_info, _ = licenses_info_to_json(transitive_licenses_info)
             licenses_json.extend(lic_info)
             for info in transitive_licenses_info.licenses.to_list():
@@ -253,6 +253,7 @@ def licenses_info_to_json(licenses_info):
                 label = _strip_null_repo(license.label),
                 used_by = ",\n          ".join(sorted(['"%s"' % x for x in used_by[str(license.label)]])),
             ))
+
             # Additionally return all File references so that other rules invoking
             # this method can load license text file contents from external repos
             # using runfiles

--- a/rules/gather_metadata.bzl
+++ b/rules/gather_metadata.bzl
@@ -15,6 +15,7 @@
 
 To be deleted before version 0.1.0
 """
+
 load(
     "@rules_license//rules_gathering:gather_metadata.bzl",
     _gather_metadata_info = "gather_metadata_info",

--- a/rules/license.bzl
+++ b/rules/license.bzl
@@ -16,12 +16,12 @@
 """
 
 load(
-    "@rules_license//rules:providers.bzl",
-    "LicenseKindInfo",
-)
-load(
     "@rules_license//rules:license_impl.bzl",
     "license_rule_impl",
+)
+load(
+    "@rules_license//rules:providers.bzl",
+    "LicenseKindInfo",
 )
 
 # Enable this if your organization requires the license text to be a file
@@ -67,7 +67,7 @@ _license = rule(
             doc = "A human readable version string identifying this package." +
                   " This may be used to produce an index of OSS packages used" +
                   " by an applicatation.  It should be a value that" +
-                  " increases over time, rather than a commit hash."
+                  " increases over time, rather than a commit hash.",
         ),
     },
 )

--- a/rules/license_kind.bzl
+++ b/rules/license_kind.bzl
@@ -55,6 +55,10 @@ def license_kind(name, **kwargs):
     """Wrapper for license_kind.
 
     @wraps(_license_kind)
+
+    Args:
+        name: name of resulting _license_kind rule
+        **kwargs: additional named parameters passed to resulting _license_kind rule
     """
     if "conditions" not in kwargs:
         kwargs["conditions"] = []

--- a/rules/licenses_core.bzl
+++ b/rules/licenses_core.bzl
@@ -87,6 +87,7 @@ def _get_transitive_metadata(ctx, trans_licenses, trans_other_metadata, trans_pa
                 if hasattr(info, "other_metadata"):
                     if info.other_metadata:
                         trans_other_metadata.append(info.other_metadata)
+
                 # But if we want more precise type safety, we would have a
                 # trans_* for each type of metadata. That is not user
                 # extensibile.
@@ -123,22 +124,20 @@ def gather_metadata_info_common(target, ctx, provider_factory, metadata_provider
     # First we gather my direct license attachments
     licenses = []
     other_metadata = []
-    package_info = []
     if ctx.rule.kind == "_license":
         # Don't try to gather licenses from the license rule itself. We'll just
         # blunder into the text file of the license and pick up the default
         # attribute of the package, which we don't want.
         pass
-    else:
-        if hasattr(ctx.rule.attr, "applicable_licenses"):
-            for dep in ctx.rule.attr.applicable_licenses:
-                if LicenseInfo in dep:
-                    lic = dep[LicenseInfo]
-                    licenses.append(lic)
+    elif hasattr(ctx.rule.attr, "applicable_licenses"):
+        for dep in ctx.rule.attr.applicable_licenses:
+            if LicenseInfo in dep:
+                lic = dep[LicenseInfo]
+                licenses.append(lic)
 
-                for m_p in metadata_providers:
-                    if m_p in dep:
-                        other_metadata.append(dep[m_p])
+            for m_p in metadata_providers:
+                if m_p in dep:
+                    other_metadata.append(dep[m_p])
 
     # A hack until https://github.com/bazelbuild/rules_license/issues/89 is
     # fully resolved. If exec is in the bin_dir path, then the current

--- a/rules/package_info.bzl
+++ b/rules/package_info.bzl
@@ -35,6 +35,7 @@ def _package_info_impl(ctx):
         package_url = ctx.attr.package_url,
         package_version = ctx.attr.package_version,
     )
+
     # Experimental alternate design, using a generic 'data' back to hold things
     generic_provider = ExperimentalMetadataInfo(
         type = "package_info_alt",
@@ -42,8 +43,8 @@ def _package_info_impl(ctx):
         data = {
             "package_name": ctx.attr.package_name or ctx.build_file_path.rstrip("/BUILD"),
             "package_url": ctx.attr.package_url,
-            "package_version": ctx.attr.package_version
-        }
+            "package_version": ctx.attr.package_version,
+        },
     )
     return [provider, generic_provider]
 
@@ -64,7 +65,7 @@ _package_info = rule(
             doc = "A human readable version string identifying this package." +
                   " This may be used to produce an index of OSS packages used" +
                   " by an applicatation.  It should be a value that" +
-                  " increases over time, rather than a commit hash."
+                  " increases over time, rather than a commit hash.",
         ),
     },
 )
@@ -86,7 +87,7 @@ def package_info(
                     may be used to produce an index of OSS packages used by
                     an application.
       package_url: str The canoncial URL this package distribution was retrieved from.
-                       Note that, because of local mirroring, that might not be the 
+                       Note that, because of local mirroring, that might not be the
                        physical URL it was retrieved from.
       package_version: str A human readable name identifying version of this package.
       kwargs: other args. Most are ignored.

--- a/rules_gathering/gather_metadata.bzl
+++ b/rules_gathering/gather_metadata.bzl
@@ -35,9 +35,9 @@ def _strip_null_repo(label):
     The is to make str(label) compatible between bazel 5.x and 6.x
     """
     s = str(label)
-    if s.startswith('@//'):
+    if s.startswith("@//"):
         return s[1:]
-    elif s.startswith('@@//'):
+    elif s.startswith("@@//"):
         return s[2:]
     return s
 
@@ -51,7 +51,8 @@ def _gather_metadata_info_impl(target, ctx):
         ctx,
         TransitiveMetadataInfo,
         [ExperimentalMetadataInfo, PackageInfo],
-        should_traverse)
+        should_traverse,
+    )
 
 gather_metadata_info = aspect(
     doc = """Collects LicenseInfo providers into a single TransitiveMetadataInfo provider.""",
@@ -249,7 +250,7 @@ def metadata_info_to_json(metadata_info):
                 package_url = license.package_url,
                 package_version = license.package_version,
                 label = _strip_null_repo(license.label),
-                bazel_package =  _bazel_package(license.label),
+                bazel_package = _bazel_package(license.label),
                 used_by = ",\n          ".join(sorted(['"%s"' % x for x in used_by[str(license.label)]])),
             ))
 
@@ -280,17 +281,18 @@ def metadata_info_to_json(metadata_info):
         if mi.type == "package_info":
             all_packages.append(package_info_template.format(
                 label = _strip_null_repo(mi.label),
-                bazel_package =  _bazel_package(mi.label),
+                bazel_package = _bazel_package(mi.label),
                 package_name = mi.package_name,
                 package_url = mi.package_url,
                 package_version = mi.package_version,
             ))
+
         # experimental: Support the ExperimentalMetadataInfo bag of data
         # WARNING: Do not depend on this. It will change without notice.
         if mi.type == "package_info_alt":
             all_packages.append(package_info_template.format(
                 label = _strip_null_repo(mi.label),
-                bazel_package =  _bazel_package(mi.label),
+                bazel_package = _bazel_package(mi.label),
                 # data is just a bag, so we need to use get() or ""
                 package_name = mi.data.get("package_name") or "",
                 package_url = mi.data.get("package_url") or "",

--- a/rules_gathering/gathering_providers.bzl
+++ b/rules_gathering/gathering_providers.bzl
@@ -19,6 +19,7 @@ to change at any release.
 
 LicensedTargetInfo = provider(
     doc = """Lists the licenses directly used by a single target.""",
+    # buildifier: disable=attr-licenses
     fields = {
         "target_under_license": "Label: The target label",
         "licenses": "list(label of a license rule)",
@@ -28,6 +29,7 @@ LicensedTargetInfo = provider(
 def licenses_info():
     return provider(
         doc = """The transitive set of licenses used by a target.""",
+        # buildifier: disable=attr-licenses
         fields = {
             "target_under_license": "Label: The top level target label.",
             "deps": "depset(LicensedTargetInfo): The transitive list of dependencies that have licenses.",
@@ -41,12 +43,12 @@ TransitiveLicensesInfo = licenses_info()
 
 TransitiveMetadataInfo = provider(
     doc = """The transitive set of licenses used by a target.""",
+    # buildifier: disable=attr-licenses
     fields = {
         "top_level_target": "Label: The top level target label we are examining.",
         "other_metadata": "depset(ExperimentalMetatdataInfo)",
         "licenses": "depset(LicenseInfo)",
         "package_info": "depset(PackageInfo)",
-
         "target_under_license": "Label: A target which will be associated with some licenses.",
         "deps": "depset(LicensedTargetInfo): The transitive list of dependencies that have licenses.",
         "traces": "list(string) - diagnostic for tracing a dependency relationship to a target.",

--- a/rules_gathering/generate_sbom.bzl
+++ b/rules_gathering/generate_sbom.bzl
@@ -16,7 +16,6 @@
 load(
     "@rules_license//rules_gathering:gather_metadata.bzl",
     "gather_metadata_info",
-    "gather_metadata_info_and_write",
     "write_metadata_info",
 )
 load(

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -113,8 +113,8 @@ py_test(
     name = "hello_licenses_test",
     srcs = ["hello_licenses_test.py"],
     data = [
-        ":hello_licenses.json",
         ":hello_cc_copyrights.txt",
+        ":hello_licenses.json",
     ],
     python_version = "PY3",
     deps = [
@@ -139,11 +139,10 @@ check_license(
     ],
 )
 
-
 license(
     name = "license_with_generated_text",
-    license_text = ":created_license",
     license_kinds = [":generic_notice_license"],
+    license_text = ":created_license",
 )
 
 genrule(
@@ -151,4 +150,3 @@ genrule(
     outs = ["something.text"],
     cmd = "echo hello >$@",
 )
-

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -17,7 +17,10 @@
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 
 package(
-    default_applicable_licenses = ["//:license", "//:package_info"],
+    default_applicable_licenses = [
+        "//:license",
+        "//:package_info",
+    ],
     default_visibility = ["//visibility:public"],
 )
 
@@ -47,15 +50,15 @@ py_library(
 py_binary(
     name = "write_sbom",
     srcs = ["write_sbom.py"],
-    deps = [":sbom_lib"],
     python_version = "PY3",
     visibility = ["//visibility:public"],
+    deps = [":sbom_lib"],
 )
 
 py_binary(
     name = "write_workspace_sbom",
     srcs = ["write_workspace_sbom.py"],
-    deps = [":sbom_lib"],
     python_version = "PY3",
     visibility = ["//visibility:public"],
+    deps = [":sbom_lib"],
 )


### PR DESCRIPTION
Similar to https://github.com/bazelbuild/examples/pull/310 This ensures that contributors outside google3 have a means to easily make buildifier-clean commits. It is purely opt-in, and we assume that google3 users will have buildifier run for them in another way.

Other than the `.pre-commit-config.yaml` change, the rest is mechanically applied by buildifier.