### PR TITLE
Replace `ctx.build_file_path`

### DIFF
--- a/rules/license_impl.bzl
+++ b/rules/license_impl.bzl
@@ -36,7 +36,7 @@ def license_rule_impl(ctx):
     provider = LicenseInfo(
         license_kinds = tuple([k[LicenseKindInfo] for k in ctx.attr.license_kinds]),
         copyright_notice = ctx.attr.copyright_notice,
-        package_name = ctx.attr.package_name or ctx.build_file_path.rstrip("/BUILD"),
+        package_name = ctx.attr.package_name or ctx.label.package,
         package_url = ctx.attr.package_url,
         package_version = ctx.attr.package_version,
         license_text = ctx.file.license_text,


### PR DESCRIPTION
Remove the use of a deprecated API.

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [x] Tests and examples for any new features.
- [x] Appropriate changes to README are included in PR
