### PR TITLE
Create ADD_PKG_MGR.md

### DIFF
--- a/docs/ADD_PKG_MGR.md
+++ b/docs/ADD_PKG_MGR.md
@@ -1,0 +1,22 @@
+# Adding support for a new package manager
+
+Bazel largely relies on existing package managers for each language ecosystem to fetch dependencies.
+Thus the knowledge of provenance and package metadata needs to be plumbed through these tools.
+
+## 
+
+In BUILD targets generated for third-party packages, implementations must create one of the following:
+
+```starlark
+load("@rules_license//rules:license.bzl", "license")
+
+package(
+   default_package_metadata = [":license"],
+)
+
+license(
+  name = "license",
+  src = ":LICENSE.txt",
+  license_kind = ["@rules_license//licenses/spdx:Apache-2.0"],
+)
+```


### PR DESCRIPTION
Allows package manager implementations like rules_jvm_external to begin declaring the licenses or other metadata about third-party packages they fetch and add to the dependency graph.

Needs some discussion with @mzeren-vmw about whether this is the shape we want to commit to, vs. having a `package_info` rule as well.
