### PR TITLE
Add `purl` to the `PackageInfo` provider

### DIFF
--- a/rules/providers.bzl
+++ b/rules/providers.bzl
@@ -55,6 +55,7 @@ PackageInfo = provider(
         "package_name": "string: Human readable package name",
         "package_url": "string: URL from which this package was downloaded.",
         "package_version": "string: Human readable version string",
+        "purl": "string: package url matching the purl spec (https://github.com/package-url/purl-spec)",
     },
 )
 


### PR DESCRIPTION
A purl is a URL string used to identify and locate a software package in a mostly universal and uniform way across programing languages, package managers, packaging conventions, tools, APIs and databases.

The most relevant usage is within a CycloneDX-format SBOM, as documented here: https://cyclonedx.org/docs/1.6/json/#components_items_purl

There is not enough information in the existing `PackageInfo` to successfully construct a valid pURL, so adding this here avoids any possible ambiguity.

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [x] Tests and examples for any new features.
- [x] Appropriate changes to README are included in PR
