### PR TITLE
include purl in sbom tooling

### DIFF
--- a/rules/package_info.bzl
+++ b/rules/package_info.bzl
@@ -34,6 +34,7 @@ def _package_info_impl(ctx):
         package_name = ctx.attr.package_name or ctx.build_file_path.rstrip("/BUILD"),
         package_url = ctx.attr.package_url,
         package_version = ctx.attr.package_version,
+        purl = ctx.attr.purl,
     )
 
     # Experimental alternate design, using a generic 'data' back to hold things
@@ -44,6 +45,7 @@ def _package_info_impl(ctx):
             "package_name": ctx.attr.package_name or ctx.build_file_path.rstrip("/BUILD"),
             "package_url": ctx.attr.package_url,
             "package_version": ctx.attr.package_version,
+            "purl": ctx.attr.purl,
         },
     )
     return [provider, generic_provider]

--- a/rules_gathering/gather_metadata.bzl
+++ b/rules_gathering/gather_metadata.bzl
@@ -215,7 +215,8 @@ def metadata_info_to_json(metadata_info):
             "bazel_package": "{bazel_package}",
             "package_name": "{package_name}",
             "package_url": "{package_url}",
-            "package_version": "{package_version}"
+            "package_version": "{package_version}",
+            "purl": "{purl}"
           }}"""
 
     # Build reverse map of license to user
@@ -284,6 +285,7 @@ def metadata_info_to_json(metadata_info):
                 package_name = mi.package_name,
                 package_url = mi.package_url,
                 package_version = mi.package_version,
+                purl = mi.purl,
             ))
         # experimental: Support the ExperimentalMetadataInfo bag of data
         # WARNING: Do not depend on this. It will change without notice.
@@ -295,6 +297,7 @@ def metadata_info_to_json(metadata_info):
                 package_name = mi.data.get("package_name") or "",
                 package_url = mi.data.get("package_url") or "",
                 package_version = mi.data.get("package_version") or "",
+                purl = mi.data.get("purl") or "",
             ))
 
     return [main_template.format(

--- a/tools/sbom.py
+++ b/tools/sbom.py
@@ -48,4 +48,6 @@ class SBOMWriter:
             if url:
                 self.out.write('  downloadLocation: %s\n' % url)
 
-
+            purl = p.get('purl')
+            if purl:
+                self.out.write('  externalRef: PACKAGE-MANAGER purl %s\n' % purl)


### PR DESCRIPTION
Followon from https://github.com/bazelbuild/rules_license/pull/143, pass any purl defined in package_info through the example sbom generators.
