### PR TITLE
Prep for 1.0.0 release

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "rules_license",
-    version = "0.0.8",  # Keep in sync with version.bzl
+    version = "1.0.0",  # Keep in sync with version.bzl
     compatibility_level = 1,
 )
 
@@ -12,6 +12,7 @@ module(
 # do not need //tools.
 
 # Only for development
-bazel_dep(name = "rules_pkg", version = "0.7.0", dev_dependency = True)
-bazel_dep(name = "rules_python", version = "0.23.0", dev_dependency = True)
-bazel_dep(name = "stardoc", version = "0.5.3", dev_dependency = True)
+bazel_dep(name = "bazel_skylib", version = "1.7.1", dev_dependency = True)
+bazel_dep(name = "rules_pkg", version = "1.0.1", dev_dependency = True)
+bazel_dep(name = "rules_python", version = "0.35.0", dev_dependency = True)
+bazel_dep(name = "stardoc", version = "0.6.2", dev_dependency = True)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,7 +18,7 @@ workspace(name = "rules_license")
 # declarations.
 #
 # If you want to use any of the reporting or SBOM tools, and you are using a
-# WORKSPACE file instead of bzlmod, they you must explicitly depend on
+# WORKSPACE file instead of bzlmod, then you should explicitly depend on
 # rules_python in your WORKSPACE.
  
 ### INTERNAL ONLY - lines after this are not included in the release packaging.
@@ -26,36 +26,43 @@ workspace(name = "rules_license")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
-   name = "rules_python",
-   sha256 = "ffc7b877c95413c82bfd5482c017edcf759a6250d8b24e82f41f3c8b8d9e287e",
-   strip_prefix = "rules_python-0.19.0",
-   urls = [
-       "https://github.com/bazelbuild/rules_python/releases/download/0.19.0/rules_python-0.19.0.tar.gz",
-   ],
+    name = "bazel_skylib",
+    sha256 = "bc283cdfcd526a52c3201279cda4bc298652efa898b10b4db0837dc51652756f",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.7.1/bazel-skylib-1.7.1.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.7.1/bazel-skylib-1.7.1.tar.gz",
+    ],
+)
+
+http_archive(
+    name = "rules_python",
+    sha256 = "be04b635c7be4604be1ef20542e9870af3c49778ce841ee2d92fcb42f9d9516a",
+    strip_prefix = "rules_python-0.35.0",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.35.0/rules_python-0.35.0.tar.gz",
 )
 
 http_archive(
     name = "rules_pkg",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.8.0/rules_pkg-0.8.0.tar.gz",
-        "https://github.com/bazelbuild/rules_pkg/releases/download/0.8.0/rules_pkg-0.8.0.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/1.0.1/rules_pkg-1.0.1.tar.gz",
+        "https://github.com/bazelbuild/rules_pkg/releases/download/1.0.1/rules_pkg-1.0.1.tar.gz",
     ],
-    sha256 = "eea0f59c28a9241156a47d7a8e32db9122f3d50b505fae0f33de6ce4d9b61834",
+    sha256 = "d20c951960ed77cb7b341c2a59488534e494d5ad1d30c4818c736d57772a9fef",
 )
-
-load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
-
-rules_pkg_dependencies()
 
 http_archive(
-    name = "io_bazel_stardoc",
-    sha256 = "3fd8fec4ddec3c670bd810904e2e33170bedfe12f90adf943508184be458c8bb",
+    name = "bazel_stardoc",
+    sha256 = "c9794dcc8026a30ff67cf7cf91ebe245ca294b20b071845d12c192afe243ad72",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/stardoc/releases/download/0.5.3/stardoc-0.5.3.tar.gz",
-        "https://github.com/bazelbuild/stardoc/releases/download/0.5.3/stardoc-0.5.3.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/stardoc/releases/download/0.5.0/stardoc-0.5.0.tar.gz",
+        "https://github.com/bazelbuild/stardoc/releases/download/0.5.0/stardoc-0.5.0.tar.gz",
     ],
 )
 
-load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
+load("@rules_python//python:repositories.bzl", "py_repositories")
+
+py_repositories()
+
+load("@bazel_stardoc//:setup.bzl", "stardoc_repositories")
 
 stardoc_repositories()

--- a/doc_build/BUILD
+++ b/doc_build/BUILD
@@ -20,7 +20,7 @@ How to:
 """
 
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@io_bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
+load("@stardoc//stardoc:stardoc.bzl", "stardoc")
 load("@rules_python//python:defs.bzl", "py_library")
 load("//:version.bzl", "version")
 

--- a/tools/test_helpers.bzl
+++ b/tools/test_helpers.bzl
@@ -60,12 +60,6 @@ def golden_cmd_test(
     """
     actual = name + ".output"
 
-    # There are some cases where tools are provided and exec_tools are provided.
-    # Specifying both in the same genrule, confuses the host vs exec rules,
-    # which prevents python3 from execution.
-    if tools and exec_tools:
-        fail("Only set one: tools or exec_tools.  " +
-             "Setting both confuses python execution mode (host vs exec).")
     native.genrule(
         name = name + "_output",
         srcs = srcs,

--- a/version.bzl
+++ b/version.bzl
@@ -13,4 +13,4 @@
 # limitations under the License.
 """The version of rules_license."""
 
-version = "0.0.8"
+version = "1.0.0"


### PR DESCRIPTION
- update to newer versions of develper dependencies
- Remove use of exec_tools from test_helpers. This was missed in 740c6005e3bf2dd6a8ef013deda44b10947b1705

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [X ] Tests pass
- [ ] Tests and examples for any new features.
- [ ] Appropriate changes to README are included in PR
