### PR TITLE
Export all the deps we need for stardoc to work

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_license//:version.bzl", "version")
 load("@rules_license//rules:license.bzl", "license")
 load("@rules_license//rules:package_info.bzl", "package_info")
-load("@rules_license//:version.bzl", "version")
 
 package(
     default_applicable_licenses = [":license", ":package_info"],
@@ -55,10 +55,20 @@ filegroup(
         "*.bzl",
         "*.md",
     ]) + [
-        "MODULE.bazel",
         "BUILD",
         "LICENSE",
+        "MODULE.bazel",
         "WORKSPACE.bzlmod",
     ],
     visibility = ["//distro:__pkg__"],
+)
+
+filegroup(
+    name = "docs_deps",
+    srcs = [
+        ":standard_package",
+        "//rules:standard_package",
+        "//rules_gathering:standard_package",
+    ],
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This enables rulesets that use `rules_license` to be properly documented via `stardoc`. Without this, `stardoc` will fail because the source files for particular rules or providers will not be available.
