### PR TITLE
Introduce a toolchain for sbom generation and manipulation.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,3 +16,5 @@ bazel_dep(name = "bazel_skylib", version = "1.7.1", dev_dependency = True)
 bazel_dep(name = "rules_pkg", version = "1.0.1", dev_dependency = True)
 bazel_dep(name = "rules_python", version = "0.35.0", dev_dependency = True)
 bazel_dep(name = "stardoc", version = "0.6.2", dev_dependency = True)
+
+register_toolchains("@rules_license//rules_gathering:example_sbom_tools_toolchain")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -66,3 +66,5 @@ py_repositories()
 load("@bazel_stardoc//:setup.bzl", "stardoc_repositories")
 
 stardoc_repositories()
+
+register_toolchains("@rules_license//rules_gathering:example_sbom_tools_toolchain")

--- a/rules_gathering/BUILD
+++ b/rules_gathering/BUILD
@@ -18,6 +18,8 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
+load(":toolchains.bzl", "sbom_tools_toolchain")
+
 filegroup(
     name = "standard_package",
     srcs = glob(["**"]),
@@ -30,4 +32,18 @@ exports_files(
         "*.bzl",
     ]),
     visibility = ["//doc_build:__pkg__"],
+)
+
+
+toolchain_type(name = "sbom_tools")
+
+sbom_tools_toolchain(
+    name = "example_sbom_tools",
+    create_intermediate_sbom_binary = "@rules_license//tools:write_sbom",
+)
+
+toolchain(
+    name = "example_sbom_tools_toolchain",
+    toolchain_type = ":sbom_tools",
+    toolchain = "example_sbom_tools",
 )

--- a/rules_gathering/toolchains.bzl
+++ b/rules_gathering/toolchains.bzl
@@ -1,0 +1,54 @@
+"""
+This module contains the provider for a sbom_tools toolchain as well as a basic implementation
+that invokes binaries directly with well known cli arguments.
+"""
+
+SbomToolsInfo = provider("Toolchain used to generate and maniputate SBOMs", fields = [
+    "create_intermediate_sbom",
+    "merge_intermediate_sboms", 
+    "convert_intermediate_sbom_to_format"
+])
+
+def _create_intermediate_sbom_builder(bin):
+    exe = bin[DefaultInfo].files_to_run.executable
+    def create_intermediate_sbom(ctx, sbom_file, licenses_file = None):
+        inputs = [licenses_file]
+        outputs = [ctx.outputs.out]
+        args = ctx.actions.args()
+        args.add("--licenses_info", licenses_file.path)
+        args.add("--out", sbom_file.path)
+        ctx.actions.run(
+            mnemonic = "CreateSBOM",
+            progress_message = "Creating SBOM for %s" % ctx.label,
+            inputs = inputs,
+            outputs = outputs,
+            executable = exe,
+            arguments = [args],
+        )
+
+        return [
+            DefaultInfo(files = depset(outputs)),
+        ]
+        
+    return create_intermediate_sbom
+
+def _sbom_tools_toolchain(ctx):
+    return [
+        platform_common.ToolchainInfo(
+            sbom_tools_info = SbomToolsInfo(
+                create_intermediate_sbom = _create_intermediate_sbom_builder(ctx.attr.create_intermediate_sbom_binary),
+            )
+        )
+    ]
+
+sbom_tools_toolchain = rule(
+    _sbom_tools_toolchain,
+    attrs = {
+        "create_intermediate_sbom_binary": attr.label(
+            executable = True,
+            allow_files = True,
+            cfg = "exec",
+            providers = [DefaultInfo],
+        ),
+    }
+)


### PR DESCRIPTION
This toolchain must support arbitrary opaque internal formats and allow for a last stage translation into whatever final SBOM format the user wants to use (eg: SPDX, CycloneDX, ...). The default toolchain is only for demonstration purposes at the moment and only allows creating SPDX SBOMs with no additional manipulations.

This PR should not change any underlying behaviour, but rather only make the SBOM behaviour modifiable by users. 