### PR TITLE
fix: allow license_text=None in license declaration

### DIFF
--- a/rules/license.bzl
+++ b/rules/license.bzl
@@ -50,7 +50,6 @@ _license = rule(
         ),
         "license_text": attr.label(
             allow_single_file = True,
-            default = "LICENSE",
             doc = "The license file.",
         ),
         "package_name": attr.string(

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -49,6 +49,13 @@ license(
     license_text = "LICENSE.extra",
 )
 
+license(
+    name = "license_without_file",
+    package_name = "A test case package",
+    license_kinds = ["//licenses/spdx:Apache-2.0"],
+    license_text = None,
+)
+
 cc_binary(
     name = "hello",
     srcs = ["hello.cc"],
@@ -89,6 +96,9 @@ java_binary(
 java_library(
     name = "j_bar",
     srcs = ["Bar.java"],
+    applicable_licenses = [
+        ":license_without_file",
+    ],
     javacopts = ["-Xep:DefaultPackage:OFF"],
 )
 
@@ -113,8 +123,8 @@ py_test(
     name = "hello_licenses_test",
     srcs = ["hello_licenses_test.py"],
     data = [
-        ":hello_licenses.json",
         ":hello_cc_copyrights.txt",
+        ":hello_licenses.json",
     ],
     python_version = "PY3",
     deps = [
@@ -139,11 +149,10 @@ check_license(
     ],
 )
 
-
 license(
     name = "license_with_generated_text",
-    license_text = ":created_license",
     license_kinds = [":generic_notice_license"],
+    license_text = ":created_license",
 )
 
 genrule(
@@ -151,4 +160,3 @@ genrule(
     outs = ["something.text"],
     cmd = "echo hello >$@",
 )
-


### PR DESCRIPTION
Fixes #31

There are many situations where the license kind is known but no license
file is available, e.g. some wheels downloaded from PyPi.

There are good reasons why one might want to prohibit that from a policy
perspective, but enforcing that policy is not the job of the license
rule itself, and the provided error message is not especially helpful
(and clearly not the intended outcome).

This doesn't alter the macro wrapper.  Any target that would be affected
by this change would have already been failing to build.