### PR TITLE
Update and improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ WARNING: The code here is still in active initial development and will churn a l
 If you want to follow along:
 - Mailing list: [bazel-ssc@bazel.build](https://groups.google.com/a/bazel.build/g/bazel-ssc)  
 - Monthly eng meeting: [calendar link](MjAyMjA4MjJUMTYwMDAwWiBjXzUzcHBwZzFudWthZXRmb3E5NzhxaXViNmxzQGc&tmsrc=c_53pppg1nukaetfoq978qiub6ls%40group.calendar.google.com&scp=ALL)
-- [Latest docs](https://bazelbuild.github.io/rules_license/latest.html)
+- [Latest docs](https://bazelbuild.github.io/rules_license/index.html)
 
 ## Roadmap
 

--- a/admin/refresh_spdx/README.md
+++ b/admin/refresh_spdx/README.md
@@ -9,12 +9,5 @@ It does not attempt to classify them in any way.
 
 NOTE: You must run this from //admin/refresh_spdx
 
-1.  Fetch the license list from the SPDX project.
-
-    ```bash
-    wget https://github.com/spdx/license-list-data/raw/master/json/licenses.json
-    ```
-
 1.  Run the refresh tool
     python add_licenses.py
-

--- a/admin/refresh_spdx/add_licenses.py
+++ b/admin/refresh_spdx/add_licenses.py
@@ -13,88 +13,91 @@ import os
 from string import Template
 import re
 import sys
+import urllib.request
+
 
 def load_json(path: str):
-  """Loads a JSON file and returns the data.
+    """Loads a JSON file and returns the data.
 
-  Args:
-    path: (str) a file path.
-  Returns:
-    (dict) the parsed data.
-  """
-  with open(path, 'r') as fp:
-    ret = json.load(fp)
-  return ret
+    Args:
+      path: (str) a file path.
+    Returns:
+      (dict) the parsed data.
+    """
+    with open(path, "r") as fp:
+        ret = json.load(fp)
+    return ret
 
 
 def parse_build_file(text: str):
-  """Parse a BUILD file of license declaration.
+    """Parse a BUILD file of license declaration.
 
-  Parses a build file and returns all the text that
-  is not licenese_kind declarations and a map of
-  license kind names to the text which declared them
+    Parses a build file and returns all the text that
+    is not licenese_kind declarations and a map of
+    license kind names to the text which declared them
 
-  license_kind(
-    name = "0BSD",
-    conditions = [],
-    url = "https://spdx.org/licenses/0BSD.html",
-  )
+    license_kind(
+      name = "0BSD",
+      conditions = [],
+      url = "https://spdx.org/licenses/0BSD.html",
+    )
 
-  Returns:
-    preamble: str 
-    targets: map<str, str>
-  """
+    Returns:
+      preamble: str
+      targets: map<str, str>
+    """
 
-  target_start = re.compile(r'^([a-zA-Z0-9_]+)\(')  # ) to fix autoindent
-  name_match = re.compile(r'^ *name *= *"([^"]*)"')
+    target_start = re.compile(r"^([a-zA-Z0-9_]+)\(")  # ) to fix autoindent
+    name_match = re.compile(r'^ *name *= *"([^"]*)"')
 
-  targets = {}
-  preamble = []
-  collecting_rule = None
+    targets = {}
+    preamble = []
+    collecting_rule = None
 
-  for line in text.split('\n'):
-    if collecting_rule:
-      collecting_rule.append(line)
-      if line.startswith(')'):
-        assert cur_name
-        targets[cur_name] = '\n'.join(collecting_rule)
-        # print(cur_name, "=====", targets[cur_name])
-        collecting_rule = None
-        cur_name = None
-      else:
-        m = name_match.match(line)
+    for line in text.split("\n"):
+        if collecting_rule:
+            collecting_rule.append(line)
+            if line.startswith(")"):
+                assert cur_name
+                targets[cur_name] = "\n".join(collecting_rule)
+                # print(cur_name, "=====", targets[cur_name])
+                collecting_rule = None
+                cur_name = None
+            else:
+                m = name_match.match(line)
+                if m:
+                    cur_name = m.group(1)
+            continue
+
+        # not collecting a rule
+        m = target_start.match(line)
         if m:
-          cur_name = m.group(1)
-      continue
+            cur_rule = m.group(1)
+            if cur_rule == "license_kind":
+                collecting_rule = [line]
+                continue
 
-    # not collecting a rule
-    m = target_start.match(line)
-    if m:
-      cur_rule = m.group(1)
-      if cur_rule == 'license_kind':
-        collecting_rule = [line]
-        continue
+        if line or preamble[-1]:
+            preamble.append(line)
 
-    if line or preamble[-1]:
-      preamble.append(line)
-
-  return '\n'.join(preamble), targets
+    return "\n".join(preamble), targets
 
 
 # Sample JSON formate license declaration.
 """
 {
-  "licenseListVersion": "3.8-57-gca4f142",
+  "licenseListVersion": "d2ce3b6",
   "licenses": [
     {
-      "reference": "./0BSD.html",
+      "reference": "https://spdx.org/licenses/0BSD.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/0BSD.json",
-      "referenceNumber": "232",
+      "detailsUrl": "https://spdx.org/licenses/0BSD.json",
+      "referenceNumber": 16,
       "name": "BSD Zero Clause License",
       "licenseId": "0BSD",
       "seeAlso": [
-        "http://landley.net/toybox/license.html"
+        "http://landley.net/toybox/license.html",
+        "https://opensource.org/licenses/0BSD"
       ],
       "isOsiApproved": true
     },
@@ -102,61 +105,78 @@ def parse_build_file(text: str):
 
 
 def insert_new(already_declared, licenses):
-  template = Template((
-      'license_kind(\n'
-      '    name = "${licenseId}",\n'
-      '    conditions = [],\n'
-      '    url = "https://spdx.org/licenses/${licenseId}.html",\n'
-      ')'))
+    template = Template(
+        (
+            "license_kind(\n"
+            '    name = "${licenseId}",\n'
+            "    conditions = [],\n"
+            '    url = "${reference}",\n'
+            ")"
+        )
+    )
 
-  for license in licenses:
-    id = license['licenseId']
-    old = already_declared.get(id)
-    if not old:
-      print('Adding:', id)
-      already_declared[id] = template.substitute(license)
+    for license in licenses:
+        id = license["licenseId"]
+        old = already_declared.get(id)
+        if not old:
+            print("Adding:", id)
+            already_declared[id] = template.substitute(license)
 
+
+def get_license_json():
+    url = "https://raw.githubusercontent.com/spdx/license-list-data/refs/heads/main/json/licenses.json"
+    return json.loads(urllib.request.urlopen(url).read())
 
 def update_spdx_build():
-  """Update //licenses/spdx/BUILD with new license kinds."""
+    """Update //licenses/spdx/BUILD with new license kinds."""
 
-  license_json = load_json('licenses.json')
+    license_json = get_license_json()
 
-  # Find workspace root
-  build_path = 'licenses/spdx/BUILD'
-  found_spdx_build = False
-  for i in range(5):  # Simple regression failure limiter
-    if os.access('WORKSPACE', os.R_OK) and os.access(build_path, os.R_OK):
-      found_spdx_build = True
-      break
-    os.chdir('..')
-  if not found_spdx_build:
-    print('Could not find', build_path)
-    return 1
+    # Find workspace root
+    build_path = "licenses/spdx/BUILD"
+    docs_path = "docs/license_kinds.md"
+    found_spdx_build = False
+    for i in range(5):  # Simple regression failure limiter
+        if os.access("WORKSPACE", os.R_OK) and os.access(build_path, os.R_OK):
+            found_spdx_build = True
+            break
+        os.chdir("..")
+    if not found_spdx_build:
+        print("Could not find", build_path)
+        return 1
 
-  with open(build_path, 'r') as fp:
-    current_file_content = fp.read()
+    with open(build_path, "r") as fp:
+        current_file_content = fp.read()
 
-  preamble, kinds = parse_build_file(current_file_content)
-  insert_new(kinds, license_json['licenses'])
-  with open(build_path, 'w') as fp:
-    fp.write(preamble)
-    for license in sorted(kinds.keys(), key=lambda x: x.lower()):
-      fp.write('\n')
-      fp.write(kinds[license])
-      fp.write('\n')
+    preamble, kinds = parse_build_file(current_file_content)
+    insert_new(kinds, license_json["licenses"])
+    with open(build_path, "w") as fp:
+        fp.write(preamble)
+        for license in sorted(kinds.keys(), key=lambda x: x.lower()):
+            fp.write("\n")
+            fp.write(kinds[license])
+            fp.write("\n")
+
+    with open(docs_path, "w") as f:
+        f.write("# SPDX License Kinds\n\n")
+        licenses = license_json["licenses"]
+        f.write("| License Name | Target Label | Reference |\n")
+        f.write("|--------------|--------------|-----------|\n")
+        for license in sorted(licenses, key=lambda x: x["name"].lower()):
+            f.write(f"| {license['name']} | `@rules_license//licenses/spdx:{license['licenseId']}` | [reference]({license['reference']}) |\n")
+
 
 
 def main():
-  lc_all = os.environ.get('LC_ALL')
-  if lc_all != 'en_US.UTF-8':
-    print('Your environment settings will reorder the file badly.')
-    print('Please rerun as:')
-    print('  LC_ALL="en_US.UTF-8"', ' '.join(sys.argv))
-    sys.exit(1)
+    lc_all = os.environ.get("LC_ALL")
+    if lc_all != "en_US.UTF-8":
+        print("Your environment settings will reorder the file badly.")
+        print("Please rerun as:")
+        print('  LC_ALL="en_US.UTF-8"', " ".join(sys.argv))
+        sys.exit(1)
 
-  update_spdx_build()
+    update_spdx_build()
 
 
-if __name__ == '__main__':
-  main()
+if __name__ == "__main__":
+    main()

--- a/doc_build/BUILD
+++ b/doc_build/BUILD
@@ -26,26 +26,6 @@ load("//:version.bzl", "version")
 
 package(default_package_metadata = ["//:license", "//:package_info"])
 
-filegroup(
-    name = "standard_package",
-    srcs = [
-        "BUILD",
-    ] + glob([
-        "*.bzl",
-        "*.py",
-    ]),
-    visibility = ["//distro:__pkg__"],
-)
-
-exports_files(
-    glob([
-        "*.bzl",
-    ]),
-    visibility = [
-        "//distro:__pkg__",
-    ],
-)
-
 # pairs of rule name and the source file to get it from
 # Must put macro wrapped rules after their wrapper
 # buildifier: leave-alone, do not sort

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,9 +1,44 @@
 # bazelbuild/rules_license
 
-Bazel rules for defining and using package licensing and other metadata
+Bazel rules for defining and using package licensing and other metadata. Use bazel-ssc@bazel.build for discussion.
 
-Use bazel-ssc@bazel.build for discussion.
+## Library Authors
+
+If you are writing a library, you should declare the licenses that apply to your library using the
+`license` rule. This will allow users of your library to easily determine the licenses that apply to
+your library.
+
+In your root `BUILD.bazel` file:
+
+```python
+load("@rules_license//rules:license.bzl", "license")
+
+license(
+    name = "license",
+    license_text = "LICENSE.txt", # This is the license file that you keep at the root of your repository
+    license_kind = "@rules_license//licenses/spdx:YOUR_SPDX_LICENSE_KIND",
+)
+```
+
+To see all of the supported spdx license kinds that `rules_license` supports, go [here](license_kinds.md).
+
+In a root-level `REPO.bazel` file:
+
+```python
+repo(
+    default_package_metadata = ["//:license"],
+)
+```
+
+This will mark all targets in your repo as using the license that your configured in your root BUILD
+file.
+
+## Generating reports / SBOMs
+
+Tooling for license reporting is under active development. See the 'examples' directory in the
+rules_license repo for examples of how to generate reports.
 
 ## Reference
 
-*   [Latest Snapshot at head](latest.md)
+* [Rules and provider reference](latest.md)
+* [SPDX license kinds](license_kinds.md)

--- a/docs/latest.md
+++ b/docs/latest.md
@@ -3,84 +3,14 @@
 Rules for declaring the compliance licenses used by a package.
 
 
-
-<a id="license"></a>
-
-## license
-
-<pre>
-license(<a href="#license-name">name</a>, <a href="#license-copyright_notice">copyright_notice</a>, <a href="#license-license_kinds">license_kinds</a>, <a href="#license-license_text">license_text</a>, <a href="#license-package_name">package_name</a>, <a href="#license-package_url">package_url</a>,
-         <a href="#license-package_version">package_version</a>)
-</pre>
-
-
-
-**ATTRIBUTES**
-
-
-| Name  | Description | Type | Mandatory | Default |
-| :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="license-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="license-copyright_notice"></a>copyright_notice |  Copyright notice.   | String | optional | <code>""</code> |
-| <a id="license-license_kinds"></a>license_kinds |  License kind(s) of this license. If multiple license kinds are listed in the LICENSE file, and they all apply, then all should be listed here. If the user can choose a single one of many, then only list one here.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
-| <a id="license-license_text"></a>license_text |  The license file.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>LICENSE</code> |
-| <a id="license-package_name"></a>package_name |  A human readable name identifying this package. This may be used to produce an index of OSS packages used by an applicatation.   | String | optional | <code>""</code> |
-| <a id="license-package_url"></a>package_url |  The URL this instance of the package was download from. This may be used to produce an index of OSS packages used by an applicatation.   | String | optional | <code>""</code> |
-| <a id="license-package_version"></a>package_version |  A human readable version string identifying this package. This may be used to produce an index of OSS packages used by an applicatation.  It should be a value that increases over time, rather than a commit hash.   | String | optional | <code>""</code> |
-
-
-
 <!-- Generated with Stardoc: http://skydoc.bazel.build -->
 
 Proof of concept. License restriction.
-
-<a id="license_kind"></a>
-
-## license_kind
-
-<pre>
-license_kind(<a href="#license_kind-name">name</a>, <a href="#license_kind-canonical_text">canonical_text</a>, <a href="#license_kind-conditions">conditions</a>, <a href="#license_kind-long_name">long_name</a>, <a href="#license_kind-url">url</a>)
-</pre>
-
-
-
-**ATTRIBUTES**
-
-
-| Name  | Description | Type | Mandatory | Default |
-| :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="license_kind-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="license_kind-canonical_text"></a>canonical_text |  File containing the canonical text for this license. Must be UTF-8 encoded.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="license_kind-conditions"></a>conditions |  Conditions to be met when using software under this license.  Conditions are defined by the organization using this license.   | List of strings | required |  |
-| <a id="license_kind-long_name"></a>long_name |  Human readable long name of license.   | String | optional | <code>""</code> |
-| <a id="license_kind-url"></a>url |  URL pointing to canonical license definition   | String | optional | <code>""</code> |
-
 
 
 <!-- Generated with Stardoc: http://skydoc.bazel.build -->
 
 Rules for declaring metadata about a package.
-
-<a id="package_info"></a>
-
-## package_info
-
-<pre>
-package_info(<a href="#package_info-name">name</a>, <a href="#package_info-package_name">package_name</a>, <a href="#package_info-package_url">package_url</a>, <a href="#package_info-package_version">package_version</a>)
-</pre>
-
-
-
-**ATTRIBUTES**
-
-
-| Name  | Description | Type | Mandatory | Default |
-| :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="package_info-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="package_info-package_name"></a>package_name |  A human readable name identifying this package. This may be used to produce an index of OSS packages used by an applicatation.   | String | optional | <code>""</code> |
-| <a id="package_info-package_url"></a>package_url |  The URL this instance of the package was download from. This may be used to produce an index of OSS packages used by an applicatation.   | String | optional | <code>""</code> |
-| <a id="package_info-package_version"></a>package_version |  A human readable version string identifying this package. This may be used to produce an index of OSS packages used by an applicatation.  It should be a value that increases over time, rather than a commit hash.   | String | optional | <code>""</code> |
-
 
 
 <!-- Generated with Stardoc: http://skydoc.bazel.build -->
@@ -91,12 +21,13 @@ This file should only contain the basic providers needed to create
 license and package_info declarations. Providers needed to gather
 them are declared in other places.
 
-
 <a id="LicenseInfo"></a>
 
 ## LicenseInfo
 
 <pre>
+load("@rules_license//rules:providers.bzl", "LicenseInfo")
+
 LicenseInfo(<a href="#LicenseInfo-copyright_notice">copyright_notice</a>, <a href="#LicenseInfo-label">label</a>, <a href="#LicenseInfo-license_kinds">license_kinds</a>, <a href="#LicenseInfo-license_text">license_text</a>, <a href="#LicenseInfo-package_name">package_name</a>, <a href="#LicenseInfo-package_url">package_url</a>,
             <a href="#LicenseInfo-package_version">package_version</a>)
 </pre>
@@ -104,7 +35,6 @@ LicenseInfo(<a href="#LicenseInfo-copyright_notice">copyright_notice</a>, <a hre
 Provides information about a license instance.
 
 **FIELDS**
-
 
 | Name  | Description |
 | :------------- | :------------- |
@@ -126,19 +56,19 @@ This file should only contain the basic providers needed to create
 license and package_info declarations. Providers needed to gather
 them are declared in other places.
 
-
 <a id="LicenseKindInfo"></a>
 
 ## LicenseKindInfo
 
 <pre>
+load("@rules_license//rules:providers.bzl", "LicenseKindInfo")
+
 LicenseKindInfo(<a href="#LicenseKindInfo-conditions">conditions</a>, <a href="#LicenseKindInfo-label">label</a>, <a href="#LicenseKindInfo-long_name">long_name</a>, <a href="#LicenseKindInfo-name">name</a>)
 </pre>
 
 Provides information about a license_kind instance.
 
 **FIELDS**
-
 
 | Name  | Description |
 | :------------- | :------------- |
@@ -157,19 +87,19 @@ This file should only contain the basic providers needed to create
 license and package_info declarations. Providers needed to gather
 them are declared in other places.
 
-
 <a id="PackageInfo"></a>
 
 ## PackageInfo
 
 <pre>
-PackageInfo(<a href="#PackageInfo-type">type</a>, <a href="#PackageInfo-label">label</a>, <a href="#PackageInfo-package_name">package_name</a>, <a href="#PackageInfo-package_url">package_url</a>, <a href="#PackageInfo-package_version">package_version</a>)
+load("@rules_license//rules:providers.bzl", "PackageInfo")
+
+PackageInfo(<a href="#PackageInfo-type">type</a>, <a href="#PackageInfo-label">label</a>, <a href="#PackageInfo-package_name">package_name</a>, <a href="#PackageInfo-package_url">package_url</a>, <a href="#PackageInfo-package_version">package_version</a>, <a href="#PackageInfo-purl">purl</a>)
 </pre>
 
 Provides information about a package.
 
 **FIELDS**
-
 
 | Name  | Description |
 | :------------- | :------------- |
@@ -178,6 +108,7 @@ Provides information about a package.
 | <a id="PackageInfo-package_name"></a>package_name |  string: Human readable package name    |
 | <a id="PackageInfo-package_url"></a>package_url |  string: URL from which this package was downloaded.    |
 | <a id="PackageInfo-package_version"></a>package_version |  string: Human readable version string    |
+| <a id="PackageInfo-purl"></a>purl |  string: package url matching the purl spec (https://github.com/package-url/purl-spec)    |
 
 
 
@@ -190,6 +121,8 @@ Rules and macros for collecting LicenseInfo providers.
 ## gather_metadata_info
 
 <pre>
+load("@rules_license//rules_gathering:gather_metadata.bzl", "gather_metadata_info")
+
 gather_metadata_info(<a href="#gather_metadata_info-name">name</a>)
 </pre>
 
@@ -198,17 +131,13 @@ Collects LicenseInfo providers into a single TransitiveMetadataInfo provider.
 **ASPECT ATTRIBUTES**
 
 
-| Name | Type |
-| :------------- | :------------- |
-| *| String |
-
 
 **ATTRIBUTES**
 
 
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="gather_metadata_info-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |   |
+| <a id="gather_metadata_info-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 
 
 
@@ -221,22 +150,19 @@ Rules and macros for collecting LicenseInfo providers.
 ## gather_metadata_info_and_write
 
 <pre>
+load("@rules_license//rules_gathering:gather_metadata.bzl", "gather_metadata_info_and_write")
+
 gather_metadata_info_and_write(<a href="#gather_metadata_info_and_write-name">name</a>)
 </pre>
 
 Collects TransitiveMetadataInfo providers and writes JSON representation to a file.
 
-    Usage:
-      bazel build //some:target           --aspects=@rules_license//rules_gathering:gather_metadata.bzl%gather_metadata_info_and_write
-          --output_groups=licenses
-    
+Usage:
+  bazel build //some:target           --aspects=@rules_license//rules_gathering:gather_metadata.bzl%gather_metadata_info_and_write
+      --output_groups=licenses
 
 **ASPECT ATTRIBUTES**
 
-
-| Name | Type |
-| :------------- | :------------- |
-| *| String |
 
 
 **ATTRIBUTES**
@@ -244,7 +170,7 @@ Collects TransitiveMetadataInfo providers and writes JSON representation to a fi
 
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="gather_metadata_info_and_write-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |   |
+| <a id="gather_metadata_info_and_write-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 
 
 
@@ -257,6 +183,8 @@ Rules and macros for collecting package metdata providers.
 ## trace
 
 <pre>
+load("@rules_license//rules_gathering:trace.bzl", "trace")
+
 trace(<a href="#trace-name">name</a>)
 </pre>
 

--- a/docs/license_kinds.md
+++ b/docs/license_kinds.md
@@ -1,0 +1,682 @@
+# SPDX License Kinds
+
+| License Name | Target Label | Reference |
+|--------------|--------------|-----------|
+| 3D Slicer License v1.0 | `@rules_license//licenses/spdx:3D-Slicer-1.0` | [reference](https://spdx.org/licenses/3D-Slicer-1.0.html) |
+| 3dfx Glide License | `@rules_license//licenses/spdx:Glide` | [reference](https://spdx.org/licenses/Glide.html) |
+| Abstyles License | `@rules_license//licenses/spdx:Abstyles` | [reference](https://spdx.org/licenses/Abstyles.html) |
+| Academic Free License v1.1 | `@rules_license//licenses/spdx:AFL-1.1` | [reference](https://spdx.org/licenses/AFL-1.1.html) |
+| Academic Free License v1.2 | `@rules_license//licenses/spdx:AFL-1.2` | [reference](https://spdx.org/licenses/AFL-1.2.html) |
+| Academic Free License v2.0 | `@rules_license//licenses/spdx:AFL-2.0` | [reference](https://spdx.org/licenses/AFL-2.0.html) |
+| Academic Free License v2.1 | `@rules_license//licenses/spdx:AFL-2.1` | [reference](https://spdx.org/licenses/AFL-2.1.html) |
+| Academic Free License v3.0 | `@rules_license//licenses/spdx:AFL-3.0` | [reference](https://spdx.org/licenses/AFL-3.0.html) |
+| Academy of Motion Picture Arts and Sciences BSD | `@rules_license//licenses/spdx:AMPAS` | [reference](https://spdx.org/licenses/AMPAS.html) |
+| AdaCore Doc License | `@rules_license//licenses/spdx:AdaCore-doc` | [reference](https://spdx.org/licenses/AdaCore-doc.html) |
+| Adaptive Public License 1.0 | `@rules_license//licenses/spdx:APL-1.0` | [reference](https://spdx.org/licenses/APL-1.0.html) |
+| Adobe Display PostScript License | `@rules_license//licenses/spdx:Adobe-Display-PostScript` | [reference](https://spdx.org/licenses/Adobe-Display-PostScript.html) |
+| Adobe Glyph List License | `@rules_license//licenses/spdx:Adobe-Glyph` | [reference](https://spdx.org/licenses/Adobe-Glyph.html) |
+| Adobe Postscript AFM License | `@rules_license//licenses/spdx:APAFML` | [reference](https://spdx.org/licenses/APAFML.html) |
+| Adobe Systems Incorporated Source Code License Agreement | `@rules_license//licenses/spdx:Adobe-2006` | [reference](https://spdx.org/licenses/Adobe-2006.html) |
+| Adobe Utopia Font License | `@rules_license//licenses/spdx:Adobe-Utopia` | [reference](https://spdx.org/licenses/Adobe-Utopia.html) |
+| Affero General Public License v1.0 | `@rules_license//licenses/spdx:AGPL-1.0` | [reference](https://spdx.org/licenses/AGPL-1.0.html) |
+| Affero General Public License v1.0 only | `@rules_license//licenses/spdx:AGPL-1.0-only` | [reference](https://spdx.org/licenses/AGPL-1.0-only.html) |
+| Affero General Public License v1.0 or later | `@rules_license//licenses/spdx:AGPL-1.0-or-later` | [reference](https://spdx.org/licenses/AGPL-1.0-or-later.html) |
+| Afmparse License | `@rules_license//licenses/spdx:Afmparse` | [reference](https://spdx.org/licenses/Afmparse.html) |
+| Aladdin Free Public License | `@rules_license//licenses/spdx:Aladdin` | [reference](https://spdx.org/licenses/Aladdin.html) |
+| Amazon Digital Services License | `@rules_license//licenses/spdx:ADSL` | [reference](https://spdx.org/licenses/ADSL.html) |
+| AMD newlib License | `@rules_license//licenses/spdx:AMD-newlib` | [reference](https://spdx.org/licenses/AMD-newlib.html) |
+| AMD's plpa_map.c License | `@rules_license//licenses/spdx:AMDPLPA` | [reference](https://spdx.org/licenses/AMDPLPA.html) |
+| AML glslang variant License | `@rules_license//licenses/spdx:AML-glslang` | [reference](https://spdx.org/licenses/AML-glslang.html) |
+| ANTLR Software Rights Notice | `@rules_license//licenses/spdx:ANTLR-PD` | [reference](https://spdx.org/licenses/ANTLR-PD.html) |
+| ANTLR Software Rights Notice with license fallback | `@rules_license//licenses/spdx:ANTLR-PD-fallback` | [reference](https://spdx.org/licenses/ANTLR-PD-fallback.html) |
+| Any OSI License | `@rules_license//licenses/spdx:any-OSI` | [reference](https://spdx.org/licenses/any-OSI.html) |
+| Any OSI License - Perl Modules | `@rules_license//licenses/spdx:any-OSI-perl-modules` | [reference](https://spdx.org/licenses/any-OSI-perl-modules.html) |
+| Apache License 1.0 | `@rules_license//licenses/spdx:Apache-1.0` | [reference](https://spdx.org/licenses/Apache-1.0.html) |
+| Apache License 1.1 | `@rules_license//licenses/spdx:Apache-1.1` | [reference](https://spdx.org/licenses/Apache-1.1.html) |
+| Apache License 2.0 | `@rules_license//licenses/spdx:Apache-2.0` | [reference](https://spdx.org/licenses/Apache-2.0.html) |
+| App::s2p License | `@rules_license//licenses/spdx:App-s2p` | [reference](https://spdx.org/licenses/App-s2p.html) |
+| Apple MIT License | `@rules_license//licenses/spdx:AML` | [reference](https://spdx.org/licenses/AML.html) |
+| Apple Public Source License 1.0 | `@rules_license//licenses/spdx:APSL-1.0` | [reference](https://spdx.org/licenses/APSL-1.0.html) |
+| Apple Public Source License 1.1 | `@rules_license//licenses/spdx:APSL-1.1` | [reference](https://spdx.org/licenses/APSL-1.1.html) |
+| Apple Public Source License 1.2 | `@rules_license//licenses/spdx:APSL-1.2` | [reference](https://spdx.org/licenses/APSL-1.2.html) |
+| Apple Public Source License 2.0 | `@rules_license//licenses/spdx:APSL-2.0` | [reference](https://spdx.org/licenses/APSL-2.0.html) |
+| Arphic Public License | `@rules_license//licenses/spdx:Arphic-1999` | [reference](https://spdx.org/licenses/Arphic-1999.html) |
+| Artistic License 1.0 | `@rules_license//licenses/spdx:Artistic-1.0` | [reference](https://spdx.org/licenses/Artistic-1.0.html) |
+| Artistic License 1.0 (Perl) | `@rules_license//licenses/spdx:Artistic-1.0-Perl` | [reference](https://spdx.org/licenses/Artistic-1.0-Perl.html) |
+| Artistic License 1.0 w/clause 8 | `@rules_license//licenses/spdx:Artistic-1.0-cl8` | [reference](https://spdx.org/licenses/Artistic-1.0-cl8.html) |
+| Artistic License 2.0 | `@rules_license//licenses/spdx:Artistic-2.0` | [reference](https://spdx.org/licenses/Artistic-2.0.html) |
+| ASWF Digital Assets License 1.1 | `@rules_license//licenses/spdx:ASWF-Digital-Assets-1.1` | [reference](https://spdx.org/licenses/ASWF-Digital-Assets-1.1.html) |
+| ASWF Digital Assets License version 1.0 | `@rules_license//licenses/spdx:ASWF-Digital-Assets-1.0` | [reference](https://spdx.org/licenses/ASWF-Digital-Assets-1.0.html) |
+| Attribution Assurance License | `@rules_license//licenses/spdx:AAL` | [reference](https://spdx.org/licenses/AAL.html) |
+| Baekmuk License | `@rules_license//licenses/spdx:Baekmuk` | [reference](https://spdx.org/licenses/Baekmuk.html) |
+| Bahyph License | `@rules_license//licenses/spdx:Bahyph` | [reference](https://spdx.org/licenses/Bahyph.html) |
+| Barr License | `@rules_license//licenses/spdx:Barr` | [reference](https://spdx.org/licenses/Barr.html) |
+| bcrypt Solar Designer License | `@rules_license//licenses/spdx:bcrypt-Solar-Designer` | [reference](https://spdx.org/licenses/bcrypt-Solar-Designer.html) |
+| Beerware License | `@rules_license//licenses/spdx:Beerware` | [reference](https://spdx.org/licenses/Beerware.html) |
+| Bitstream Charter Font License | `@rules_license//licenses/spdx:Bitstream-Charter` | [reference](https://spdx.org/licenses/Bitstream-Charter.html) |
+| Bitstream Vera Font License | `@rules_license//licenses/spdx:Bitstream-Vera` | [reference](https://spdx.org/licenses/Bitstream-Vera.html) |
+| BitTorrent Open Source License v1.0 | `@rules_license//licenses/spdx:BitTorrent-1.0` | [reference](https://spdx.org/licenses/BitTorrent-1.0.html) |
+| BitTorrent Open Source License v1.1 | `@rules_license//licenses/spdx:BitTorrent-1.1` | [reference](https://spdx.org/licenses/BitTorrent-1.1.html) |
+| Blue Oak Model License 1.0.0 | `@rules_license//licenses/spdx:BlueOak-1.0.0` | [reference](https://spdx.org/licenses/BlueOak-1.0.0.html) |
+| Boehm-Demers-Weiser GC License | `@rules_license//licenses/spdx:Boehm-GC` | [reference](https://spdx.org/licenses/Boehm-GC.html) |
+| Boehm-Demers-Weiser GC License (without fee) | `@rules_license//licenses/spdx:Boehm-GC-without-fee` | [reference](https://spdx.org/licenses/Boehm-GC-without-fee.html) |
+| Boost Software License 1.0 | `@rules_license//licenses/spdx:BSL-1.0` | [reference](https://spdx.org/licenses/BSL-1.0.html) |
+| Borceux license | `@rules_license//licenses/spdx:Borceux` | [reference](https://spdx.org/licenses/Borceux.html) |
+| Brian Gladman 2-Clause License | `@rules_license//licenses/spdx:Brian-Gladman-2-Clause` | [reference](https://spdx.org/licenses/Brian-Gladman-2-Clause.html) |
+| Brian Gladman 3-Clause License | `@rules_license//licenses/spdx:Brian-Gladman-3-Clause` | [reference](https://spdx.org/licenses/Brian-Gladman-3-Clause.html) |
+| BSD 1-Clause License | `@rules_license//licenses/spdx:BSD-1-Clause` | [reference](https://spdx.org/licenses/BSD-1-Clause.html) |
+| BSD 2-Clause "Simplified" License | `@rules_license//licenses/spdx:BSD-2-Clause` | [reference](https://spdx.org/licenses/BSD-2-Clause.html) |
+| BSD 2-Clause - first lines requirement | `@rules_license//licenses/spdx:BSD-2-Clause-first-lines` | [reference](https://spdx.org/licenses/BSD-2-Clause-first-lines.html) |
+| BSD 2-Clause - Ian Darwin variant | `@rules_license//licenses/spdx:BSD-2-Clause-Darwin` | [reference](https://spdx.org/licenses/BSD-2-Clause-Darwin.html) |
+| BSD 2-Clause FreeBSD License | `@rules_license//licenses/spdx:BSD-2-Clause-FreeBSD` | [reference](https://spdx.org/licenses/BSD-2-Clause-FreeBSD.html) |
+| BSD 2-Clause NetBSD License | `@rules_license//licenses/spdx:BSD-2-Clause-NetBSD` | [reference](https://spdx.org/licenses/BSD-2-Clause-NetBSD.html) |
+| BSD 2-Clause with views sentence | `@rules_license//licenses/spdx:BSD-2-Clause-Views` | [reference](https://spdx.org/licenses/BSD-2-Clause-Views.html) |
+| BSD 3-Clause "New" or "Revised" License | `@rules_license//licenses/spdx:BSD-3-Clause` | [reference](https://spdx.org/licenses/BSD-3-Clause.html) |
+| BSD 3-Clause acpica variant | `@rules_license//licenses/spdx:BSD-3-Clause-acpica` | [reference](https://spdx.org/licenses/BSD-3-Clause-acpica.html) |
+| BSD 3-Clause Clear License | `@rules_license//licenses/spdx:BSD-3-Clause-Clear` | [reference](https://spdx.org/licenses/BSD-3-Clause-Clear.html) |
+| BSD 3-Clause Flex variant | `@rules_license//licenses/spdx:BSD-3-Clause-flex` | [reference](https://spdx.org/licenses/BSD-3-Clause-flex.html) |
+| BSD 3-Clause Modification | `@rules_license//licenses/spdx:BSD-3-Clause-Modification` | [reference](https://spdx.org/licenses/BSD-3-Clause-Modification.html) |
+| BSD 3-Clause No Military License | `@rules_license//licenses/spdx:BSD-3-Clause-No-Military-License` | [reference](https://spdx.org/licenses/BSD-3-Clause-No-Military-License.html) |
+| BSD 3-Clause No Nuclear License | `@rules_license//licenses/spdx:BSD-3-Clause-No-Nuclear-License` | [reference](https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License.html) |
+| BSD 3-Clause No Nuclear License 2014 | `@rules_license//licenses/spdx:BSD-3-Clause-No-Nuclear-License-2014` | [reference](https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License-2014.html) |
+| BSD 3-Clause No Nuclear Warranty | `@rules_license//licenses/spdx:BSD-3-Clause-No-Nuclear-Warranty` | [reference](https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-Warranty.html) |
+| BSD 3-Clause Open MPI variant | `@rules_license//licenses/spdx:BSD-3-Clause-Open-MPI` | [reference](https://spdx.org/licenses/BSD-3-Clause-Open-MPI.html) |
+| BSD 3-Clause Sun Microsystems | `@rules_license//licenses/spdx:BSD-3-Clause-Sun` | [reference](https://spdx.org/licenses/BSD-3-Clause-Sun.html) |
+| BSD 4 Clause Shortened | `@rules_license//licenses/spdx:BSD-4-Clause-Shortened` | [reference](https://spdx.org/licenses/BSD-4-Clause-Shortened.html) |
+| BSD 4-Clause "Original" or "Old" License | `@rules_license//licenses/spdx:BSD-4-Clause` | [reference](https://spdx.org/licenses/BSD-4-Clause.html) |
+| BSD 4.3 RENO License | `@rules_license//licenses/spdx:BSD-4.3RENO` | [reference](https://spdx.org/licenses/BSD-4.3RENO.html) |
+| BSD 4.3 TAHOE License | `@rules_license//licenses/spdx:BSD-4.3TAHOE` | [reference](https://spdx.org/licenses/BSD-4.3TAHOE.html) |
+| BSD Advertising Acknowledgement License | `@rules_license//licenses/spdx:BSD-Advertising-Acknowledgement` | [reference](https://spdx.org/licenses/BSD-Advertising-Acknowledgement.html) |
+| BSD Protection License | `@rules_license//licenses/spdx:BSD-Protection` | [reference](https://spdx.org/licenses/BSD-Protection.html) |
+| BSD Source Code Attribution | `@rules_license//licenses/spdx:BSD-Source-Code` | [reference](https://spdx.org/licenses/BSD-Source-Code.html) |
+| BSD Source Code Attribution - beginning of file variant | `@rules_license//licenses/spdx:BSD-Source-beginning-file` | [reference](https://spdx.org/licenses/BSD-Source-beginning-file.html) |
+| BSD with attribution | `@rules_license//licenses/spdx:BSD-3-Clause-Attribution` | [reference](https://spdx.org/licenses/BSD-3-Clause-Attribution.html) |
+| BSD with Attribution and HPND disclaimer | `@rules_license//licenses/spdx:BSD-Attribution-HPND-disclaimer` | [reference](https://spdx.org/licenses/BSD-Attribution-HPND-disclaimer.html) |
+| BSD Zero Clause License | `@rules_license//licenses/spdx:0BSD` | [reference](https://spdx.org/licenses/0BSD.html) |
+| BSD-2-Clause Plus Patent License | `@rules_license//licenses/spdx:BSD-2-Clause-Patent` | [reference](https://spdx.org/licenses/BSD-2-Clause-Patent.html) |
+| BSD-4-Clause (University of California-Specific) | `@rules_license//licenses/spdx:BSD-4-Clause-UC` | [reference](https://spdx.org/licenses/BSD-4-Clause-UC.html) |
+| BSD-Inferno-Nettverk | `@rules_license//licenses/spdx:BSD-Inferno-Nettverk` | [reference](https://spdx.org/licenses/BSD-Inferno-Nettverk.html) |
+| Business Source License 1.1 | `@rules_license//licenses/spdx:BUSL-1.1` | [reference](https://spdx.org/licenses/BUSL-1.1.html) |
+| bzip2 and libbzip2 License v1.0.5 | `@rules_license//licenses/spdx:bzip2-1.0.5` | [reference](https://spdx.org/licenses/bzip2-1.0.5.html) |
+| bzip2 and libbzip2 License v1.0.6 | `@rules_license//licenses/spdx:bzip2-1.0.6` | [reference](https://spdx.org/licenses/bzip2-1.0.6.html) |
+| Caldera License | `@rules_license//licenses/spdx:Caldera` | [reference](https://spdx.org/licenses/Caldera.html) |
+| Caldera License (without preamble) | `@rules_license//licenses/spdx:Caldera-no-preamble` | [reference](https://spdx.org/licenses/Caldera-no-preamble.html) |
+| Catharon License | `@rules_license//licenses/spdx:Catharon` | [reference](https://spdx.org/licenses/Catharon.html) |
+| CeCILL Free Software License Agreement v1.0 | `@rules_license//licenses/spdx:CECILL-1.0` | [reference](https://spdx.org/licenses/CECILL-1.0.html) |
+| CeCILL Free Software License Agreement v1.1 | `@rules_license//licenses/spdx:CECILL-1.1` | [reference](https://spdx.org/licenses/CECILL-1.1.html) |
+| CeCILL Free Software License Agreement v2.0 | `@rules_license//licenses/spdx:CECILL-2.0` | [reference](https://spdx.org/licenses/CECILL-2.0.html) |
+| CeCILL Free Software License Agreement v2.1 | `@rules_license//licenses/spdx:CECILL-2.1` | [reference](https://spdx.org/licenses/CECILL-2.1.html) |
+| CeCILL-B Free Software License Agreement | `@rules_license//licenses/spdx:CECILL-B` | [reference](https://spdx.org/licenses/CECILL-B.html) |
+| CeCILL-C Free Software License Agreement | `@rules_license//licenses/spdx:CECILL-C` | [reference](https://spdx.org/licenses/CECILL-C.html) |
+| CERN Open Hardware Licence v1.1 | `@rules_license//licenses/spdx:CERN-OHL-1.1` | [reference](https://spdx.org/licenses/CERN-OHL-1.1.html) |
+| CERN Open Hardware Licence v1.2 | `@rules_license//licenses/spdx:CERN-OHL-1.2` | [reference](https://spdx.org/licenses/CERN-OHL-1.2.html) |
+| CERN Open Hardware Licence Version 2 - Permissive | `@rules_license//licenses/spdx:CERN-OHL-P-2.0` | [reference](https://spdx.org/licenses/CERN-OHL-P-2.0.html) |
+| CERN Open Hardware Licence Version 2 - Strongly Reciprocal | `@rules_license//licenses/spdx:CERN-OHL-S-2.0` | [reference](https://spdx.org/licenses/CERN-OHL-S-2.0.html) |
+| CERN Open Hardware Licence Version 2 - Weakly Reciprocal | `@rules_license//licenses/spdx:CERN-OHL-W-2.0` | [reference](https://spdx.org/licenses/CERN-OHL-W-2.0.html) |
+| CFITSIO License | `@rules_license//licenses/spdx:CFITSIO` | [reference](https://spdx.org/licenses/CFITSIO.html) |
+| check-cvs License | `@rules_license//licenses/spdx:check-cvs` | [reference](https://spdx.org/licenses/check-cvs.html) |
+| Checkmk License | `@rules_license//licenses/spdx:checkmk` | [reference](https://spdx.org/licenses/checkmk.html) |
+| Clarified Artistic License | `@rules_license//licenses/spdx:ClArtistic` | [reference](https://spdx.org/licenses/ClArtistic.html) |
+| Clips License | `@rules_license//licenses/spdx:Clips` | [reference](https://spdx.org/licenses/Clips.html) |
+| CMU    Mach - no notices-in-documentation variant | `@rules_license//licenses/spdx:CMU-Mach-nodoc` | [reference](https://spdx.org/licenses/CMU-Mach-nodoc.html) |
+| CMU License | `@rules_license//licenses/spdx:MIT-CMU` | [reference](https://spdx.org/licenses/MIT-CMU.html) |
+| CMU Mach License | `@rules_license//licenses/spdx:CMU-Mach` | [reference](https://spdx.org/licenses/CMU-Mach.html) |
+| CNRI Jython License | `@rules_license//licenses/spdx:CNRI-Jython` | [reference](https://spdx.org/licenses/CNRI-Jython.html) |
+| CNRI Python License | `@rules_license//licenses/spdx:CNRI-Python` | [reference](https://spdx.org/licenses/CNRI-Python.html) |
+| CNRI Python Open Source GPL Compatible License Agreement | `@rules_license//licenses/spdx:CNRI-Python-GPL-Compatible` | [reference](https://spdx.org/licenses/CNRI-Python-GPL-Compatible.html) |
+| Code Project Open License 1.02 | `@rules_license//licenses/spdx:CPOL-1.02` | [reference](https://spdx.org/licenses/CPOL-1.02.html) |
+| Common Development and Distribution License 1.0 | `@rules_license//licenses/spdx:CDDL-1.0` | [reference](https://spdx.org/licenses/CDDL-1.0.html) |
+| Common Development and Distribution License 1.1 | `@rules_license//licenses/spdx:CDDL-1.1` | [reference](https://spdx.org/licenses/CDDL-1.1.html) |
+| Common Documentation License 1.0 | `@rules_license//licenses/spdx:CDL-1.0` | [reference](https://spdx.org/licenses/CDL-1.0.html) |
+| Common Lisp LOOP License | `@rules_license//licenses/spdx:LOOP` | [reference](https://spdx.org/licenses/LOOP.html) |
+| Common Public Attribution License 1.0 | `@rules_license//licenses/spdx:CPAL-1.0` | [reference](https://spdx.org/licenses/CPAL-1.0.html) |
+| Common Public License 1.0 | `@rules_license//licenses/spdx:CPL-1.0` | [reference](https://spdx.org/licenses/CPL-1.0.html) |
+| Common Vulnerability Enumeration ToU License | `@rules_license//licenses/spdx:cve-tou` | [reference](https://spdx.org/licenses/cve-tou.html) |
+| Community Data License Agreement Permissive 1.0 | `@rules_license//licenses/spdx:CDLA-Permissive-1.0` | [reference](https://spdx.org/licenses/CDLA-Permissive-1.0.html) |
+| Community Data License Agreement Permissive 2.0 | `@rules_license//licenses/spdx:CDLA-Permissive-2.0` | [reference](https://spdx.org/licenses/CDLA-Permissive-2.0.html) |
+| Community Data License Agreement Sharing 1.0 | `@rules_license//licenses/spdx:CDLA-Sharing-1.0` | [reference](https://spdx.org/licenses/CDLA-Sharing-1.0.html) |
+| Community Specification License 1.0 | `@rules_license//licenses/spdx:Community-Spec-1.0` | [reference](https://spdx.org/licenses/Community-Spec-1.0.html) |
+| Computational Use of Data Agreement v1.0 | `@rules_license//licenses/spdx:C-UDA-1.0` | [reference](https://spdx.org/licenses/C-UDA-1.0.html) |
+| Computer Associates Trusted Open Source License 1.1 | `@rules_license//licenses/spdx:CATOSL-1.1` | [reference](https://spdx.org/licenses/CATOSL-1.1.html) |
+| Condor Public License v1.1 | `@rules_license//licenses/spdx:Condor-1.1` | [reference](https://spdx.org/licenses/Condor-1.1.html) |
+| Copyfree Open Innovation License | `@rules_license//licenses/spdx:COIL-1.0` | [reference](https://spdx.org/licenses/COIL-1.0.html) |
+| copyleft-next 0.3.0 | `@rules_license//licenses/spdx:copyleft-next-0.3.0` | [reference](https://spdx.org/licenses/copyleft-next-0.3.0.html) |
+| copyleft-next 0.3.1 | `@rules_license//licenses/spdx:copyleft-next-0.3.1` | [reference](https://spdx.org/licenses/copyleft-next-0.3.1.html) |
+| Cornell Lossless JPEG License | `@rules_license//licenses/spdx:Cornell-Lossless-JPEG` | [reference](https://spdx.org/licenses/Cornell-Lossless-JPEG.html) |
+| Creative    Commons Public Domain Mark 1.0 Universal | `@rules_license//licenses/spdx:CC-PDM-1.0` | [reference](https://spdx.org/licenses/CC-PDM-1.0.html) |
+| Creative Commons Attribution 1.0 Generic | `@rules_license//licenses/spdx:CC-BY-1.0` | [reference](https://spdx.org/licenses/CC-BY-1.0.html) |
+| Creative Commons Attribution 2.0 Generic | `@rules_license//licenses/spdx:CC-BY-2.0` | [reference](https://spdx.org/licenses/CC-BY-2.0.html) |
+| Creative Commons Attribution 2.5 Australia | `@rules_license//licenses/spdx:CC-BY-2.5-AU` | [reference](https://spdx.org/licenses/CC-BY-2.5-AU.html) |
+| Creative Commons Attribution 2.5 Generic | `@rules_license//licenses/spdx:CC-BY-2.5` | [reference](https://spdx.org/licenses/CC-BY-2.5.html) |
+| Creative Commons Attribution 3.0 Australia | `@rules_license//licenses/spdx:CC-BY-3.0-AU` | [reference](https://spdx.org/licenses/CC-BY-3.0-AU.html) |
+| Creative Commons Attribution 3.0 Austria | `@rules_license//licenses/spdx:CC-BY-3.0-AT` | [reference](https://spdx.org/licenses/CC-BY-3.0-AT.html) |
+| Creative Commons Attribution 3.0 Germany | `@rules_license//licenses/spdx:CC-BY-3.0-DE` | [reference](https://spdx.org/licenses/CC-BY-3.0-DE.html) |
+| Creative Commons Attribution 3.0 IGO | `@rules_license//licenses/spdx:CC-BY-3.0-IGO` | [reference](https://spdx.org/licenses/CC-BY-3.0-IGO.html) |
+| Creative Commons Attribution 3.0 Netherlands | `@rules_license//licenses/spdx:CC-BY-3.0-NL` | [reference](https://spdx.org/licenses/CC-BY-3.0-NL.html) |
+| Creative Commons Attribution 3.0 United States | `@rules_license//licenses/spdx:CC-BY-3.0-US` | [reference](https://spdx.org/licenses/CC-BY-3.0-US.html) |
+| Creative Commons Attribution 3.0 Unported | `@rules_license//licenses/spdx:CC-BY-3.0` | [reference](https://spdx.org/licenses/CC-BY-3.0.html) |
+| Creative Commons Attribution 4.0 International | `@rules_license//licenses/spdx:CC-BY-4.0` | [reference](https://spdx.org/licenses/CC-BY-4.0.html) |
+| Creative Commons Attribution No Derivatives 1.0 Generic | `@rules_license//licenses/spdx:CC-BY-ND-1.0` | [reference](https://spdx.org/licenses/CC-BY-ND-1.0.html) |
+| Creative Commons Attribution No Derivatives 2.0 Generic | `@rules_license//licenses/spdx:CC-BY-ND-2.0` | [reference](https://spdx.org/licenses/CC-BY-ND-2.0.html) |
+| Creative Commons Attribution No Derivatives 2.5 Generic | `@rules_license//licenses/spdx:CC-BY-ND-2.5` | [reference](https://spdx.org/licenses/CC-BY-ND-2.5.html) |
+| Creative Commons Attribution No Derivatives 3.0 Germany | `@rules_license//licenses/spdx:CC-BY-ND-3.0-DE` | [reference](https://spdx.org/licenses/CC-BY-ND-3.0-DE.html) |
+| Creative Commons Attribution No Derivatives 3.0 Unported | `@rules_license//licenses/spdx:CC-BY-ND-3.0` | [reference](https://spdx.org/licenses/CC-BY-ND-3.0.html) |
+| Creative Commons Attribution No Derivatives 4.0 International | `@rules_license//licenses/spdx:CC-BY-ND-4.0` | [reference](https://spdx.org/licenses/CC-BY-ND-4.0.html) |
+| Creative Commons Attribution Non Commercial 1.0 Generic | `@rules_license//licenses/spdx:CC-BY-NC-1.0` | [reference](https://spdx.org/licenses/CC-BY-NC-1.0.html) |
+| Creative Commons Attribution Non Commercial 2.0 Generic | `@rules_license//licenses/spdx:CC-BY-NC-2.0` | [reference](https://spdx.org/licenses/CC-BY-NC-2.0.html) |
+| Creative Commons Attribution Non Commercial 2.5 Generic | `@rules_license//licenses/spdx:CC-BY-NC-2.5` | [reference](https://spdx.org/licenses/CC-BY-NC-2.5.html) |
+| Creative Commons Attribution Non Commercial 3.0 Germany | `@rules_license//licenses/spdx:CC-BY-NC-3.0-DE` | [reference](https://spdx.org/licenses/CC-BY-NC-3.0-DE.html) |
+| Creative Commons Attribution Non Commercial 3.0 Unported | `@rules_license//licenses/spdx:CC-BY-NC-3.0` | [reference](https://spdx.org/licenses/CC-BY-NC-3.0.html) |
+| Creative Commons Attribution Non Commercial 4.0 International | `@rules_license//licenses/spdx:CC-BY-NC-4.0` | [reference](https://spdx.org/licenses/CC-BY-NC-4.0.html) |
+| Creative Commons Attribution Non Commercial No Derivatives 1.0 Generic | `@rules_license//licenses/spdx:CC-BY-NC-ND-1.0` | [reference](https://spdx.org/licenses/CC-BY-NC-ND-1.0.html) |
+| Creative Commons Attribution Non Commercial No Derivatives 2.0 Generic | `@rules_license//licenses/spdx:CC-BY-NC-ND-2.0` | [reference](https://spdx.org/licenses/CC-BY-NC-ND-2.0.html) |
+| Creative Commons Attribution Non Commercial No Derivatives 2.5 Generic | `@rules_license//licenses/spdx:CC-BY-NC-ND-2.5` | [reference](https://spdx.org/licenses/CC-BY-NC-ND-2.5.html) |
+| Creative Commons Attribution Non Commercial No Derivatives 3.0 Germany | `@rules_license//licenses/spdx:CC-BY-NC-ND-3.0-DE` | [reference](https://spdx.org/licenses/CC-BY-NC-ND-3.0-DE.html) |
+| Creative Commons Attribution Non Commercial No Derivatives 3.0 IGO | `@rules_license//licenses/spdx:CC-BY-NC-ND-3.0-IGO` | [reference](https://spdx.org/licenses/CC-BY-NC-ND-3.0-IGO.html) |
+| Creative Commons Attribution Non Commercial No Derivatives 3.0 Unported | `@rules_license//licenses/spdx:CC-BY-NC-ND-3.0` | [reference](https://spdx.org/licenses/CC-BY-NC-ND-3.0.html) |
+| Creative Commons Attribution Non Commercial No Derivatives 4.0 International | `@rules_license//licenses/spdx:CC-BY-NC-ND-4.0` | [reference](https://spdx.org/licenses/CC-BY-NC-ND-4.0.html) |
+| Creative Commons Attribution Non Commercial Share Alike 1.0 Generic | `@rules_license//licenses/spdx:CC-BY-NC-SA-1.0` | [reference](https://spdx.org/licenses/CC-BY-NC-SA-1.0.html) |
+| Creative Commons Attribution Non Commercial Share Alike 2.0 England and Wales | `@rules_license//licenses/spdx:CC-BY-NC-SA-2.0-UK` | [reference](https://spdx.org/licenses/CC-BY-NC-SA-2.0-UK.html) |
+| Creative Commons Attribution Non Commercial Share Alike 2.0 Generic | `@rules_license//licenses/spdx:CC-BY-NC-SA-2.0` | [reference](https://spdx.org/licenses/CC-BY-NC-SA-2.0.html) |
+| Creative Commons Attribution Non Commercial Share Alike 2.0 Germany | `@rules_license//licenses/spdx:CC-BY-NC-SA-2.0-DE` | [reference](https://spdx.org/licenses/CC-BY-NC-SA-2.0-DE.html) |
+| Creative Commons Attribution Non Commercial Share Alike 2.5 Generic | `@rules_license//licenses/spdx:CC-BY-NC-SA-2.5` | [reference](https://spdx.org/licenses/CC-BY-NC-SA-2.5.html) |
+| Creative Commons Attribution Non Commercial Share Alike 3.0 Germany | `@rules_license//licenses/spdx:CC-BY-NC-SA-3.0-DE` | [reference](https://spdx.org/licenses/CC-BY-NC-SA-3.0-DE.html) |
+| Creative Commons Attribution Non Commercial Share Alike 3.0 IGO | `@rules_license//licenses/spdx:CC-BY-NC-SA-3.0-IGO` | [reference](https://spdx.org/licenses/CC-BY-NC-SA-3.0-IGO.html) |
+| Creative Commons Attribution Non Commercial Share Alike 3.0 Unported | `@rules_license//licenses/spdx:CC-BY-NC-SA-3.0` | [reference](https://spdx.org/licenses/CC-BY-NC-SA-3.0.html) |
+| Creative Commons Attribution Non Commercial Share Alike 4.0 International | `@rules_license//licenses/spdx:CC-BY-NC-SA-4.0` | [reference](https://spdx.org/licenses/CC-BY-NC-SA-4.0.html) |
+| Creative Commons Attribution Share Alike 1.0 Generic | `@rules_license//licenses/spdx:CC-BY-SA-1.0` | [reference](https://spdx.org/licenses/CC-BY-SA-1.0.html) |
+| Creative Commons Attribution Share Alike 2.0 England and Wales | `@rules_license//licenses/spdx:CC-BY-SA-2.0-UK` | [reference](https://spdx.org/licenses/CC-BY-SA-2.0-UK.html) |
+| Creative Commons Attribution Share Alike 2.0 Generic | `@rules_license//licenses/spdx:CC-BY-SA-2.0` | [reference](https://spdx.org/licenses/CC-BY-SA-2.0.html) |
+| Creative Commons Attribution Share Alike 2.1 Japan | `@rules_license//licenses/spdx:CC-BY-SA-2.1-JP` | [reference](https://spdx.org/licenses/CC-BY-SA-2.1-JP.html) |
+| Creative Commons Attribution Share Alike 2.5 Generic | `@rules_license//licenses/spdx:CC-BY-SA-2.5` | [reference](https://spdx.org/licenses/CC-BY-SA-2.5.html) |
+| Creative Commons Attribution Share Alike 3.0 Austria | `@rules_license//licenses/spdx:CC-BY-SA-3.0-AT` | [reference](https://spdx.org/licenses/CC-BY-SA-3.0-AT.html) |
+| Creative Commons Attribution Share Alike 3.0 Germany | `@rules_license//licenses/spdx:CC-BY-SA-3.0-DE` | [reference](https://spdx.org/licenses/CC-BY-SA-3.0-DE.html) |
+| Creative Commons Attribution Share Alike 3.0 Unported | `@rules_license//licenses/spdx:CC-BY-SA-3.0` | [reference](https://spdx.org/licenses/CC-BY-SA-3.0.html) |
+| Creative Commons Attribution Share Alike 4.0 International | `@rules_license//licenses/spdx:CC-BY-SA-4.0` | [reference](https://spdx.org/licenses/CC-BY-SA-4.0.html) |
+| Creative Commons Attribution-NonCommercial-ShareAlike 2.0 France | `@rules_license//licenses/spdx:CC-BY-NC-SA-2.0-FR` | [reference](https://spdx.org/licenses/CC-BY-NC-SA-2.0-FR.html) |
+| Creative Commons Attribution-ShareAlike 3.0 IGO | `@rules_license//licenses/spdx:CC-BY-SA-3.0-IGO` | [reference](https://spdx.org/licenses/CC-BY-SA-3.0-IGO.html) |
+| Creative Commons Public Domain Dedication and Certification | `@rules_license//licenses/spdx:CC-PDDC` | [reference](https://spdx.org/licenses/CC-PDDC.html) |
+| Creative Commons Share Alike 1.0 Generic | `@rules_license//licenses/spdx:CC-SA-1.0` | [reference](https://spdx.org/licenses/CC-SA-1.0.html) |
+| Creative Commons Zero v1.0 Universal | `@rules_license//licenses/spdx:CC0-1.0` | [reference](https://spdx.org/licenses/CC0-1.0.html) |
+| Cronyx License | `@rules_license//licenses/spdx:Cronyx` | [reference](https://spdx.org/licenses/Cronyx.html) |
+| Crossword License | `@rules_license//licenses/spdx:Crossword` | [reference](https://spdx.org/licenses/Crossword.html) |
+| Cryptographic Autonomy License 1.0 | `@rules_license//licenses/spdx:CAL-1.0` | [reference](https://spdx.org/licenses/CAL-1.0.html) |
+| Cryptographic Autonomy License 1.0 (Combined Work Exception) | `@rules_license//licenses/spdx:CAL-1.0-Combined-Work-Exception` | [reference](https://spdx.org/licenses/CAL-1.0-Combined-Work-Exception.html) |
+| CrystalStacker License | `@rules_license//licenses/spdx:CrystalStacker` | [reference](https://spdx.org/licenses/CrystalStacker.html) |
+| CUA Office Public License v1.0 | `@rules_license//licenses/spdx:CUA-OPL-1.0` | [reference](https://spdx.org/licenses/CUA-OPL-1.0.html) |
+| Cube License | `@rules_license//licenses/spdx:Cube` | [reference](https://spdx.org/licenses/Cube.html) |
+| curl License | `@rules_license//licenses/spdx:curl` | [reference](https://spdx.org/licenses/curl.html) |
+| Data licence Germany – attribution – version 2.0 | `@rules_license//licenses/spdx:DL-DE-BY-2.0` | [reference](https://spdx.org/licenses/DL-DE-BY-2.0.html) |
+| Data licence Germany – zero – version 2.0 | `@rules_license//licenses/spdx:DL-DE-ZERO-2.0` | [reference](https://spdx.org/licenses/DL-DE-ZERO-2.0.html) |
+| David M. Gay dtoa License | `@rules_license//licenses/spdx:dtoa` | [reference](https://spdx.org/licenses/dtoa.html) |
+| DEC 3-Clause License | `@rules_license//licenses/spdx:DEC-3-Clause` | [reference](https://spdx.org/licenses/DEC-3-Clause.html) |
+| Detection Rule License 1.0 | `@rules_license//licenses/spdx:DRL-1.0` | [reference](https://spdx.org/licenses/DRL-1.0.html) |
+| Detection Rule License 1.1 | `@rules_license//licenses/spdx:DRL-1.1` | [reference](https://spdx.org/licenses/DRL-1.1.html) |
+| Deutsche Freie Software Lizenz | `@rules_license//licenses/spdx:D-FSL-1.0` | [reference](https://spdx.org/licenses/D-FSL-1.0.html) |
+| diffmark license | `@rules_license//licenses/spdx:diffmark` | [reference](https://spdx.org/licenses/diffmark.html) |
+| Do What The F*ck You Want To Public License | `@rules_license//licenses/spdx:WTFPL` | [reference](https://spdx.org/licenses/WTFPL.html) |
+| DOC License | `@rules_license//licenses/spdx:DOC` | [reference](https://spdx.org/licenses/DOC.html) |
+| DocBook Schema License | `@rules_license//licenses/spdx:DocBook-Schema` | [reference](https://spdx.org/licenses/DocBook-Schema.html) |
+| DocBook Stylesheet License | `@rules_license//licenses/spdx:DocBook-Stylesheet` | [reference](https://spdx.org/licenses/DocBook-Stylesheet.html) |
+| DocBook XML License | `@rules_license//licenses/spdx:DocBook-XML` | [reference](https://spdx.org/licenses/DocBook-XML.html) |
+| Dotseqn License | `@rules_license//licenses/spdx:Dotseqn` | [reference](https://spdx.org/licenses/Dotseqn.html) |
+| DSDP License | `@rules_license//licenses/spdx:DSDP` | [reference](https://spdx.org/licenses/DSDP.html) |
+| dvipdfm License | `@rules_license//licenses/spdx:dvipdfm` | [reference](https://spdx.org/licenses/dvipdfm.html) |
+| Eclipse Public License 1.0 | `@rules_license//licenses/spdx:EPL-1.0` | [reference](https://spdx.org/licenses/EPL-1.0.html) |
+| Eclipse Public License 2.0 | `@rules_license//licenses/spdx:EPL-2.0` | [reference](https://spdx.org/licenses/EPL-2.0.html) |
+| eCos license version 2.0 | `@rules_license//licenses/spdx:eCos-2.0` | [reference](https://spdx.org/licenses/eCos-2.0.html) |
+| Educational Community License v1.0 | `@rules_license//licenses/spdx:ECL-1.0` | [reference](https://spdx.org/licenses/ECL-1.0.html) |
+| Educational Community License v2.0 | `@rules_license//licenses/spdx:ECL-2.0` | [reference](https://spdx.org/licenses/ECL-2.0.html) |
+| eGenix.com Public License 1.1.0 | `@rules_license//licenses/spdx:eGenix` | [reference](https://spdx.org/licenses/eGenix.html) |
+| Eiffel Forum License v1.0 | `@rules_license//licenses/spdx:EFL-1.0` | [reference](https://spdx.org/licenses/EFL-1.0.html) |
+| Eiffel Forum License v2.0 | `@rules_license//licenses/spdx:EFL-2.0` | [reference](https://spdx.org/licenses/EFL-2.0.html) |
+| Elastic License 2.0 | `@rules_license//licenses/spdx:Elastic-2.0` | [reference](https://spdx.org/licenses/Elastic-2.0.html) |
+| Enlightenment License (e16) | `@rules_license//licenses/spdx:MIT-advertising` | [reference](https://spdx.org/licenses/MIT-advertising.html) |
+| enna License | `@rules_license//licenses/spdx:MIT-enna` | [reference](https://spdx.org/licenses/MIT-enna.html) |
+| Entessa Public License v1.0 | `@rules_license//licenses/spdx:Entessa` | [reference](https://spdx.org/licenses/Entessa.html) |
+| EPICS Open License | `@rules_license//licenses/spdx:EPICS` | [reference](https://spdx.org/licenses/EPICS.html) |
+| Erlang Public License v1.1 | `@rules_license//licenses/spdx:ErlPL-1.1` | [reference](https://spdx.org/licenses/ErlPL-1.1.html) |
+| Etalab Open License 2.0 | `@rules_license//licenses/spdx:etalab-2.0` | [reference](https://spdx.org/licenses/etalab-2.0.html) |
+| EU DataGrid Software License | `@rules_license//licenses/spdx:EUDatagrid` | [reference](https://spdx.org/licenses/EUDatagrid.html) |
+| European Union Public License 1.0 | `@rules_license//licenses/spdx:EUPL-1.0` | [reference](https://spdx.org/licenses/EUPL-1.0.html) |
+| European Union Public License 1.1 | `@rules_license//licenses/spdx:EUPL-1.1` | [reference](https://spdx.org/licenses/EUPL-1.1.html) |
+| European Union Public License 1.2 | `@rules_license//licenses/spdx:EUPL-1.2` | [reference](https://spdx.org/licenses/EUPL-1.2.html) |
+| Eurosym License | `@rules_license//licenses/spdx:Eurosym` | [reference](https://spdx.org/licenses/Eurosym.html) |
+| Fair License | `@rules_license//licenses/spdx:Fair` | [reference](https://spdx.org/licenses/Fair.html) |
+| feh License | `@rules_license//licenses/spdx:MIT-feh` | [reference](https://spdx.org/licenses/MIT-feh.html) |
+| Ferguson Twofish License | `@rules_license//licenses/spdx:Ferguson-Twofish` | [reference](https://spdx.org/licenses/Ferguson-Twofish.html) |
+| Frameworx Open License 1.0 | `@rules_license//licenses/spdx:Frameworx-1.0` | [reference](https://spdx.org/licenses/Frameworx-1.0.html) |
+| Fraunhofer FDK AAC Codec Library | `@rules_license//licenses/spdx:FDK-AAC` | [reference](https://spdx.org/licenses/FDK-AAC.html) |
+| FreeBSD Documentation License | `@rules_license//licenses/spdx:FreeBSD-DOC` | [reference](https://spdx.org/licenses/FreeBSD-DOC.html) |
+| FreeImage Public License v1.0 | `@rules_license//licenses/spdx:FreeImage` | [reference](https://spdx.org/licenses/FreeImage.html) |
+| Freetype Project License | `@rules_license//licenses/spdx:FTL` | [reference](https://spdx.org/licenses/FTL.html) |
+| FSF All Permissive License | `@rules_license//licenses/spdx:FSFAP` | [reference](https://spdx.org/licenses/FSFAP.html) |
+| FSF All Permissive License (without Warranty) | `@rules_license//licenses/spdx:FSFAP-no-warranty-disclaimer` | [reference](https://spdx.org/licenses/FSFAP-no-warranty-disclaimer.html) |
+| FSF Unlimited License | `@rules_license//licenses/spdx:FSFUL` | [reference](https://spdx.org/licenses/FSFUL.html) |
+| FSF Unlimited License (With License Retention and Warranty Disclaimer) | `@rules_license//licenses/spdx:FSFULLRWD` | [reference](https://spdx.org/licenses/FSFULLRWD.html) |
+| FSF Unlimited License (with License Retention) | `@rules_license//licenses/spdx:FSFULLR` | [reference](https://spdx.org/licenses/FSFULLR.html) |
+| Furuseth License | `@rules_license//licenses/spdx:Furuseth` | [reference](https://spdx.org/licenses/Furuseth.html) |
+| Fuzzy Bitmap License | `@rules_license//licenses/spdx:FBM` | [reference](https://spdx.org/licenses/FBM.html) |
+| fwlw License | `@rules_license//licenses/spdx:fwlw` | [reference](https://spdx.org/licenses/fwlw.html) |
+| GD License | `@rules_license//licenses/spdx:GD` | [reference](https://spdx.org/licenses/GD.html) |
+| Generic XTS License | `@rules_license//licenses/spdx:generic-xts` | [reference](https://spdx.org/licenses/generic-xts.html) |
+| Giftware License | `@rules_license//licenses/spdx:Giftware` | [reference](https://spdx.org/licenses/Giftware.html) |
+| GL2PS License | `@rules_license//licenses/spdx:GL2PS` | [reference](https://spdx.org/licenses/GL2PS.html) |
+| Glulxe License | `@rules_license//licenses/spdx:Glulxe` | [reference](https://spdx.org/licenses/Glulxe.html) |
+| Gnome GCR Documentation License | `@rules_license//licenses/spdx:GCR-docs` | [reference](https://spdx.org/licenses/GCR-docs.html) |
+| GNU Affero General Public License v3.0 | `@rules_license//licenses/spdx:AGPL-3.0` | [reference](https://spdx.org/licenses/AGPL-3.0.html) |
+| GNU Affero General Public License v3.0 only | `@rules_license//licenses/spdx:AGPL-3.0-only` | [reference](https://spdx.org/licenses/AGPL-3.0-only.html) |
+| GNU Affero General Public License v3.0 or later | `@rules_license//licenses/spdx:AGPL-3.0-or-later` | [reference](https://spdx.org/licenses/AGPL-3.0-or-later.html) |
+| GNU Free Documentation License v1.1 | `@rules_license//licenses/spdx:GFDL-1.1` | [reference](https://spdx.org/licenses/GFDL-1.1.html) |
+| GNU Free Documentation License v1.1 only | `@rules_license//licenses/spdx:GFDL-1.1-only` | [reference](https://spdx.org/licenses/GFDL-1.1-only.html) |
+| GNU Free Documentation License v1.1 only - invariants | `@rules_license//licenses/spdx:GFDL-1.1-invariants-only` | [reference](https://spdx.org/licenses/GFDL-1.1-invariants-only.html) |
+| GNU Free Documentation License v1.1 only - no invariants | `@rules_license//licenses/spdx:GFDL-1.1-no-invariants-only` | [reference](https://spdx.org/licenses/GFDL-1.1-no-invariants-only.html) |
+| GNU Free Documentation License v1.1 or later | `@rules_license//licenses/spdx:GFDL-1.1-or-later` | [reference](https://spdx.org/licenses/GFDL-1.1-or-later.html) |
+| GNU Free Documentation License v1.1 or later - invariants | `@rules_license//licenses/spdx:GFDL-1.1-invariants-or-later` | [reference](https://spdx.org/licenses/GFDL-1.1-invariants-or-later.html) |
+| GNU Free Documentation License v1.1 or later - no invariants | `@rules_license//licenses/spdx:GFDL-1.1-no-invariants-or-later` | [reference](https://spdx.org/licenses/GFDL-1.1-no-invariants-or-later.html) |
+| GNU Free Documentation License v1.2 | `@rules_license//licenses/spdx:GFDL-1.2` | [reference](https://spdx.org/licenses/GFDL-1.2.html) |
+| GNU Free Documentation License v1.2 only | `@rules_license//licenses/spdx:GFDL-1.2-only` | [reference](https://spdx.org/licenses/GFDL-1.2-only.html) |
+| GNU Free Documentation License v1.2 only - invariants | `@rules_license//licenses/spdx:GFDL-1.2-invariants-only` | [reference](https://spdx.org/licenses/GFDL-1.2-invariants-only.html) |
+| GNU Free Documentation License v1.2 only - no invariants | `@rules_license//licenses/spdx:GFDL-1.2-no-invariants-only` | [reference](https://spdx.org/licenses/GFDL-1.2-no-invariants-only.html) |
+| GNU Free Documentation License v1.2 or later | `@rules_license//licenses/spdx:GFDL-1.2-or-later` | [reference](https://spdx.org/licenses/GFDL-1.2-or-later.html) |
+| GNU Free Documentation License v1.2 or later - invariants | `@rules_license//licenses/spdx:GFDL-1.2-invariants-or-later` | [reference](https://spdx.org/licenses/GFDL-1.2-invariants-or-later.html) |
+| GNU Free Documentation License v1.2 or later - no invariants | `@rules_license//licenses/spdx:GFDL-1.2-no-invariants-or-later` | [reference](https://spdx.org/licenses/GFDL-1.2-no-invariants-or-later.html) |
+| GNU Free Documentation License v1.3 | `@rules_license//licenses/spdx:GFDL-1.3` | [reference](https://spdx.org/licenses/GFDL-1.3.html) |
+| GNU Free Documentation License v1.3 only | `@rules_license//licenses/spdx:GFDL-1.3-only` | [reference](https://spdx.org/licenses/GFDL-1.3-only.html) |
+| GNU Free Documentation License v1.3 only - invariants | `@rules_license//licenses/spdx:GFDL-1.3-invariants-only` | [reference](https://spdx.org/licenses/GFDL-1.3-invariants-only.html) |
+| GNU Free Documentation License v1.3 only - no invariants | `@rules_license//licenses/spdx:GFDL-1.3-no-invariants-only` | [reference](https://spdx.org/licenses/GFDL-1.3-no-invariants-only.html) |
+| GNU Free Documentation License v1.3 or later | `@rules_license//licenses/spdx:GFDL-1.3-or-later` | [reference](https://spdx.org/licenses/GFDL-1.3-or-later.html) |
+| GNU Free Documentation License v1.3 or later - invariants | `@rules_license//licenses/spdx:GFDL-1.3-invariants-or-later` | [reference](https://spdx.org/licenses/GFDL-1.3-invariants-or-later.html) |
+| GNU Free Documentation License v1.3 or later - no invariants | `@rules_license//licenses/spdx:GFDL-1.3-no-invariants-or-later` | [reference](https://spdx.org/licenses/GFDL-1.3-no-invariants-or-later.html) |
+| GNU General Public License v1.0 only | `@rules_license//licenses/spdx:GPL-1.0` | [reference](https://spdx.org/licenses/GPL-1.0.html) |
+| GNU General Public License v1.0 only | `@rules_license//licenses/spdx:GPL-1.0-only` | [reference](https://spdx.org/licenses/GPL-1.0-only.html) |
+| GNU General Public License v1.0 or later | `@rules_license//licenses/spdx:GPL-1.0+` | [reference](https://spdx.org/licenses/GPL-1.0+.html) |
+| GNU General Public License v1.0 or later | `@rules_license//licenses/spdx:GPL-1.0-or-later` | [reference](https://spdx.org/licenses/GPL-1.0-or-later.html) |
+| GNU General Public License v2.0 only | `@rules_license//licenses/spdx:GPL-2.0` | [reference](https://spdx.org/licenses/GPL-2.0.html) |
+| GNU General Public License v2.0 only | `@rules_license//licenses/spdx:GPL-2.0-only` | [reference](https://spdx.org/licenses/GPL-2.0-only.html) |
+| GNU General Public License v2.0 or later | `@rules_license//licenses/spdx:GPL-2.0+` | [reference](https://spdx.org/licenses/GPL-2.0+.html) |
+| GNU General Public License v2.0 or later | `@rules_license//licenses/spdx:GPL-2.0-or-later` | [reference](https://spdx.org/licenses/GPL-2.0-or-later.html) |
+| GNU General Public License v2.0 w/Autoconf exception | `@rules_license//licenses/spdx:GPL-2.0-with-autoconf-exception` | [reference](https://spdx.org/licenses/GPL-2.0-with-autoconf-exception.html) |
+| GNU General Public License v2.0 w/Bison exception | `@rules_license//licenses/spdx:GPL-2.0-with-bison-exception` | [reference](https://spdx.org/licenses/GPL-2.0-with-bison-exception.html) |
+| GNU General Public License v2.0 w/Classpath exception | `@rules_license//licenses/spdx:GPL-2.0-with-classpath-exception` | [reference](https://spdx.org/licenses/GPL-2.0-with-classpath-exception.html) |
+| GNU General Public License v2.0 w/Font exception | `@rules_license//licenses/spdx:GPL-2.0-with-font-exception` | [reference](https://spdx.org/licenses/GPL-2.0-with-font-exception.html) |
+| GNU General Public License v2.0 w/GCC Runtime Library exception | `@rules_license//licenses/spdx:GPL-2.0-with-GCC-exception` | [reference](https://spdx.org/licenses/GPL-2.0-with-GCC-exception.html) |
+| GNU General Public License v3.0 only | `@rules_license//licenses/spdx:GPL-3.0` | [reference](https://spdx.org/licenses/GPL-3.0.html) |
+| GNU General Public License v3.0 only | `@rules_license//licenses/spdx:GPL-3.0-only` | [reference](https://spdx.org/licenses/GPL-3.0-only.html) |
+| GNU General Public License v3.0 or later | `@rules_license//licenses/spdx:GPL-3.0+` | [reference](https://spdx.org/licenses/GPL-3.0+.html) |
+| GNU General Public License v3.0 or later | `@rules_license//licenses/spdx:GPL-3.0-or-later` | [reference](https://spdx.org/licenses/GPL-3.0-or-later.html) |
+| GNU General Public License v3.0 w/Autoconf exception | `@rules_license//licenses/spdx:GPL-3.0-with-autoconf-exception` | [reference](https://spdx.org/licenses/GPL-3.0-with-autoconf-exception.html) |
+| GNU General Public License v3.0 w/GCC Runtime Library exception | `@rules_license//licenses/spdx:GPL-3.0-with-GCC-exception` | [reference](https://spdx.org/licenses/GPL-3.0-with-GCC-exception.html) |
+| GNU Lesser General Public License v2.1 only | `@rules_license//licenses/spdx:LGPL-2.1` | [reference](https://spdx.org/licenses/LGPL-2.1.html) |
+| GNU Lesser General Public License v2.1 only | `@rules_license//licenses/spdx:LGPL-2.1-only` | [reference](https://spdx.org/licenses/LGPL-2.1-only.html) |
+| GNU Lesser General Public License v2.1 or later | `@rules_license//licenses/spdx:LGPL-2.1+` | [reference](https://spdx.org/licenses/LGPL-2.1+.html) |
+| GNU Lesser General Public License v2.1 or later | `@rules_license//licenses/spdx:LGPL-2.1-or-later` | [reference](https://spdx.org/licenses/LGPL-2.1-or-later.html) |
+| GNU Lesser General Public License v3.0 only | `@rules_license//licenses/spdx:LGPL-3.0` | [reference](https://spdx.org/licenses/LGPL-3.0.html) |
+| GNU Lesser General Public License v3.0 only | `@rules_license//licenses/spdx:LGPL-3.0-only` | [reference](https://spdx.org/licenses/LGPL-3.0-only.html) |
+| GNU Lesser General Public License v3.0 or later | `@rules_license//licenses/spdx:LGPL-3.0+` | [reference](https://spdx.org/licenses/LGPL-3.0+.html) |
+| GNU Lesser General Public License v3.0 or later | `@rules_license//licenses/spdx:LGPL-3.0-or-later` | [reference](https://spdx.org/licenses/LGPL-3.0-or-later.html) |
+| GNU Library General Public License v2 only | `@rules_license//licenses/spdx:LGPL-2.0` | [reference](https://spdx.org/licenses/LGPL-2.0.html) |
+| GNU Library General Public License v2 only | `@rules_license//licenses/spdx:LGPL-2.0-only` | [reference](https://spdx.org/licenses/LGPL-2.0-only.html) |
+| GNU Library General Public License v2 or later | `@rules_license//licenses/spdx:LGPL-2.0+` | [reference](https://spdx.org/licenses/LGPL-2.0+.html) |
+| GNU Library General Public License v2 or later | `@rules_license//licenses/spdx:LGPL-2.0-or-later` | [reference](https://spdx.org/licenses/LGPL-2.0-or-later.html) |
+| gnuplot License | `@rules_license//licenses/spdx:gnuplot` | [reference](https://spdx.org/licenses/gnuplot.html) |
+| Good Luck With That Public License | `@rules_license//licenses/spdx:GLWTPL` | [reference](https://spdx.org/licenses/GLWTPL.html) |
+| Graphics Gems License | `@rules_license//licenses/spdx:Graphics-Gems` | [reference](https://spdx.org/licenses/Graphics-Gems.html) |
+| gSOAP Public License v1.3b | `@rules_license//licenses/spdx:gSOAP-1.3b` | [reference](https://spdx.org/licenses/gSOAP-1.3b.html) |
+| gtkbook License | `@rules_license//licenses/spdx:gtkbook` | [reference](https://spdx.org/licenses/gtkbook.html) |
+| Gutmann License | `@rules_license//licenses/spdx:Gutmann` | [reference](https://spdx.org/licenses/Gutmann.html) |
+| Haskell Language Report License | `@rules_license//licenses/spdx:HaskellReport` | [reference](https://spdx.org/licenses/HaskellReport.html) |
+| hdparm License | `@rules_license//licenses/spdx:hdparm` | [reference](https://spdx.org/licenses/hdparm.html) |
+| Hewlett-Packard 1986 License | `@rules_license//licenses/spdx:HP-1986` | [reference](https://spdx.org/licenses/HP-1986.html) |
+| Hewlett-Packard 1989 License | `@rules_license//licenses/spdx:HP-1989` | [reference](https://spdx.org/licenses/HP-1989.html) |
+| Hewlett-Packard BSD variant license | `@rules_license//licenses/spdx:BSD-3-Clause-HP` | [reference](https://spdx.org/licenses/BSD-3-Clause-HP.html) |
+| HIDAPI License | `@rules_license//licenses/spdx:HIDAPI` | [reference](https://spdx.org/licenses/HIDAPI.html) |
+| Hippocratic License 2.1 | `@rules_license//licenses/spdx:Hippocratic-2.1` | [reference](https://spdx.org/licenses/Hippocratic-2.1.html) |
+| Historical Permission Notice and Disclaimer | `@rules_license//licenses/spdx:HPND` | [reference](https://spdx.org/licenses/HPND.html) |
+| Historical Permission Notice and Disclaimer    - INRIA-IMAG variant | `@rules_license//licenses/spdx:HPND-INRIA-IMAG` | [reference](https://spdx.org/licenses/HPND-INRIA-IMAG.html) |
+| Historical Permission Notice and Disclaimer - DEC variant | `@rules_license//licenses/spdx:HPND-DEC` | [reference](https://spdx.org/licenses/HPND-DEC.html) |
+| Historical Permission Notice and Disclaimer - documentation sell variant | `@rules_license//licenses/spdx:HPND-doc-sell` | [reference](https://spdx.org/licenses/HPND-doc-sell.html) |
+| Historical Permission Notice and Disclaimer - documentation variant | `@rules_license//licenses/spdx:HPND-doc` | [reference](https://spdx.org/licenses/HPND-doc.html) |
+| Historical Permission Notice and Disclaimer - Fenneberg-Livingston variant | `@rules_license//licenses/spdx:HPND-Fenneberg-Livingston` | [reference](https://spdx.org/licenses/HPND-Fenneberg-Livingston.html) |
+| Historical Permission Notice and Disclaimer - Intel variant | `@rules_license//licenses/spdx:HPND-Intel` | [reference](https://spdx.org/licenses/HPND-Intel.html) |
+| Historical Permission Notice and Disclaimer - Kevlin Henney variant | `@rules_license//licenses/spdx:HPND-Kevlin-Henney` | [reference](https://spdx.org/licenses/HPND-Kevlin-Henney.html) |
+| Historical Permission Notice and Disclaimer - Markus Kuhn variant | `@rules_license//licenses/spdx:HPND-Markus-Kuhn` | [reference](https://spdx.org/licenses/HPND-Markus-Kuhn.html) |
+| Historical Permission Notice and Disclaimer - merchantability variant | `@rules_license//licenses/spdx:HPND-merchantability-variant` | [reference](https://spdx.org/licenses/HPND-merchantability-variant.html) |
+| Historical Permission Notice and Disclaimer - Netrek variant | `@rules_license//licenses/spdx:HPND-Netrek` | [reference](https://spdx.org/licenses/HPND-Netrek.html) |
+| Historical Permission Notice and Disclaimer - Pbmplus variant | `@rules_license//licenses/spdx:HPND-Pbmplus` | [reference](https://spdx.org/licenses/HPND-Pbmplus.html) |
+| Historical Permission Notice and Disclaimer - sell regexpr variant | `@rules_license//licenses/spdx:HPND-sell-regexpr` | [reference](https://spdx.org/licenses/HPND-sell-regexpr.html) |
+| Historical Permission Notice and Disclaimer - sell variant | `@rules_license//licenses/spdx:HPND-sell-variant` | [reference](https://spdx.org/licenses/HPND-sell-variant.html) |
+| Historical Permission Notice and Disclaimer - sell xserver variant with MIT disclaimer | `@rules_license//licenses/spdx:HPND-sell-MIT-disclaimer-xserver` | [reference](https://spdx.org/licenses/HPND-sell-MIT-disclaimer-xserver.html) |
+| Historical Permission Notice and Disclaimer - University of California variant | `@rules_license//licenses/spdx:HPND-UC` | [reference](https://spdx.org/licenses/HPND-UC.html) |
+| Historical Permission Notice and Disclaimer - University of California, US export warning | `@rules_license//licenses/spdx:HPND-UC-export-US` | [reference](https://spdx.org/licenses/HPND-UC-export-US.html) |
+| Historical Permission Notice and Disclaimer with MIT disclaimer | `@rules_license//licenses/spdx:HPND-MIT-disclaimer` | [reference](https://spdx.org/licenses/HPND-MIT-disclaimer.html) |
+| HPND sell variant with MIT disclaimer | `@rules_license//licenses/spdx:HPND-sell-variant-MIT-disclaimer` | [reference](https://spdx.org/licenses/HPND-sell-variant-MIT-disclaimer.html) |
+| HPND sell variant with MIT disclaimer - reverse | `@rules_license//licenses/spdx:HPND-sell-variant-MIT-disclaimer-rev` | [reference](https://spdx.org/licenses/HPND-sell-variant-MIT-disclaimer-rev.html) |
+| HPND with US Government export control and 2 disclaimers | `@rules_license//licenses/spdx:HPND-export2-US` | [reference](https://spdx.org/licenses/HPND-export2-US.html) |
+| HPND with US Government export control warning | `@rules_license//licenses/spdx:HPND-export-US` | [reference](https://spdx.org/licenses/HPND-export-US.html) |
+| HPND with US Government export control warning and acknowledgment | `@rules_license//licenses/spdx:HPND-export-US-acknowledgement` | [reference](https://spdx.org/licenses/HPND-export-US-acknowledgement.html) |
+| HPND with US Government export control warning and modification rqmt | `@rules_license//licenses/spdx:HPND-export-US-modify` | [reference](https://spdx.org/licenses/HPND-export-US-modify.html) |
+| HTML Tidy License | `@rules_license//licenses/spdx:HTMLTIDY` | [reference](https://spdx.org/licenses/HTMLTIDY.html) |
+| IBM PowerPC Initialization and Boot Software | `@rules_license//licenses/spdx:IBM-pibs` | [reference](https://spdx.org/licenses/IBM-pibs.html) |
+| IBM Public License v1.0 | `@rules_license//licenses/spdx:IPL-1.0` | [reference](https://spdx.org/licenses/IPL-1.0.html) |
+| ICU License | `@rules_license//licenses/spdx:ICU` | [reference](https://spdx.org/licenses/ICU.html) |
+| IEC    Code Components End-user licence agreement | `@rules_license//licenses/spdx:IEC-Code-Components-EULA` | [reference](https://spdx.org/licenses/IEC-Code-Components-EULA.html) |
+| ImageMagick License | `@rules_license//licenses/spdx:ImageMagick` | [reference](https://spdx.org/licenses/ImageMagick.html) |
+| iMatix Standard Function Library Agreement | `@rules_license//licenses/spdx:iMatix` | [reference](https://spdx.org/licenses/iMatix.html) |
+| Imlib2 License | `@rules_license//licenses/spdx:Imlib2` | [reference](https://spdx.org/licenses/Imlib2.html) |
+| Independent JPEG Group License | `@rules_license//licenses/spdx:IJG` | [reference](https://spdx.org/licenses/IJG.html) |
+| Independent JPEG Group License - short | `@rules_license//licenses/spdx:IJG-short` | [reference](https://spdx.org/licenses/IJG-short.html) |
+| Info-ZIP License | `@rules_license//licenses/spdx:Info-ZIP` | [reference](https://spdx.org/licenses/Info-ZIP.html) |
+| Inner Net License v2.0 | `@rules_license//licenses/spdx:Inner-Net-2.0` | [reference](https://spdx.org/licenses/Inner-Net-2.0.html) |
+| Inno Setup License | `@rules_license//licenses/spdx:InnoSetup` | [reference](https://spdx.org/licenses/InnoSetup.html) |
+| Intel ACPI Software License Agreement | `@rules_license//licenses/spdx:Intel-ACPI` | [reference](https://spdx.org/licenses/Intel-ACPI.html) |
+| Intel Open Source License | `@rules_license//licenses/spdx:Intel` | [reference](https://spdx.org/licenses/Intel.html) |
+| Interbase Public License v1.0 | `@rules_license//licenses/spdx:Interbase-1.0` | [reference](https://spdx.org/licenses/Interbase-1.0.html) |
+| IPA Font License | `@rules_license//licenses/spdx:IPA` | [reference](https://spdx.org/licenses/IPA.html) |
+| ISC License | `@rules_license//licenses/spdx:ISC` | [reference](https://spdx.org/licenses/ISC.html) |
+| ISC Veillard variant | `@rules_license//licenses/spdx:ISC-Veillard` | [reference](https://spdx.org/licenses/ISC-Veillard.html) |
+| Jam License | `@rules_license//licenses/spdx:Jam` | [reference](https://spdx.org/licenses/Jam.html) |
+| Japan Network Information Center License | `@rules_license//licenses/spdx:JPNIC` | [reference](https://spdx.org/licenses/JPNIC.html) |
+| JasPer License | `@rules_license//licenses/spdx:JasPer-2.0` | [reference](https://spdx.org/licenses/JasPer-2.0.html) |
+| JPL Image Use Policy | `@rules_license//licenses/spdx:JPL-image` | [reference](https://spdx.org/licenses/JPL-image.html) |
+| JSON License | `@rules_license//licenses/spdx:JSON` | [reference](https://spdx.org/licenses/JSON.html) |
+| Kastrup License | `@rules_license//licenses/spdx:Kastrup` | [reference](https://spdx.org/licenses/Kastrup.html) |
+| Kazlib License | `@rules_license//licenses/spdx:Kazlib` | [reference](https://spdx.org/licenses/Kazlib.html) |
+| Knuth CTAN License | `@rules_license//licenses/spdx:Knuth-CTAN` | [reference](https://spdx.org/licenses/Knuth-CTAN.html) |
+| LaTeX Project Public License v1.0 | `@rules_license//licenses/spdx:LPPL-1.0` | [reference](https://spdx.org/licenses/LPPL-1.0.html) |
+| LaTeX Project Public License v1.1 | `@rules_license//licenses/spdx:LPPL-1.1` | [reference](https://spdx.org/licenses/LPPL-1.1.html) |
+| LaTeX Project Public License v1.2 | `@rules_license//licenses/spdx:LPPL-1.2` | [reference](https://spdx.org/licenses/LPPL-1.2.html) |
+| LaTeX Project Public License v1.3a | `@rules_license//licenses/spdx:LPPL-1.3a` | [reference](https://spdx.org/licenses/LPPL-1.3a.html) |
+| LaTeX Project Public License v1.3c | `@rules_license//licenses/spdx:LPPL-1.3c` | [reference](https://spdx.org/licenses/LPPL-1.3c.html) |
+| Latex2e License | `@rules_license//licenses/spdx:Latex2e` | [reference](https://spdx.org/licenses/Latex2e.html) |
+| Latex2e with translated notice permission | `@rules_license//licenses/spdx:Latex2e-translated-notice` | [reference](https://spdx.org/licenses/Latex2e-translated-notice.html) |
+| Lawrence Berkeley National Labs BSD variant license | `@rules_license//licenses/spdx:BSD-3-Clause-LBNL` | [reference](https://spdx.org/licenses/BSD-3-Clause-LBNL.html) |
+| Leptonica License | `@rules_license//licenses/spdx:Leptonica` | [reference](https://spdx.org/licenses/Leptonica.html) |
+| Lesser General Public License For Linguistic Resources | `@rules_license//licenses/spdx:LGPLLR` | [reference](https://spdx.org/licenses/LGPLLR.html) |
+| libpng License | `@rules_license//licenses/spdx:Libpng` | [reference](https://spdx.org/licenses/Libpng.html) |
+| libselinux public domain notice | `@rules_license//licenses/spdx:libselinux-1.0` | [reference](https://spdx.org/licenses/libselinux-1.0.html) |
+| libtiff License | `@rules_license//licenses/spdx:libtiff` | [reference](https://spdx.org/licenses/libtiff.html) |
+| libutil David Nugent License | `@rules_license//licenses/spdx:libutil-David-Nugent` | [reference](https://spdx.org/licenses/libutil-David-Nugent.html) |
+| Licence Art Libre 1.2 | `@rules_license//licenses/spdx:LAL-1.2` | [reference](https://spdx.org/licenses/LAL-1.2.html) |
+| Licence Art Libre 1.3 | `@rules_license//licenses/spdx:LAL-1.3` | [reference](https://spdx.org/licenses/LAL-1.3.html) |
+| Licence Libre du Québec – Permissive version 1.1 | `@rules_license//licenses/spdx:LiLiQ-P-1.1` | [reference](https://spdx.org/licenses/LiLiQ-P-1.1.html) |
+| Licence Libre du Québec – Réciprocité forte version 1.1 | `@rules_license//licenses/spdx:LiLiQ-Rplus-1.1` | [reference](https://spdx.org/licenses/LiLiQ-Rplus-1.1.html) |
+| Licence Libre du Québec – Réciprocité version 1.1 | `@rules_license//licenses/spdx:LiLiQ-R-1.1` | [reference](https://spdx.org/licenses/LiLiQ-R-1.1.html) |
+| Linux Kernel Variant of OpenIB.org license | `@rules_license//licenses/spdx:Linux-OpenIB` | [reference](https://spdx.org/licenses/Linux-OpenIB.html) |
+| Linux man-pages - 1 paragraph | `@rules_license//licenses/spdx:Linux-man-pages-1-para` | [reference](https://spdx.org/licenses/Linux-man-pages-1-para.html) |
+| Linux man-pages Copyleft | `@rules_license//licenses/spdx:Linux-man-pages-copyleft` | [reference](https://spdx.org/licenses/Linux-man-pages-copyleft.html) |
+| Linux man-pages Copyleft - 2 paragraphs | `@rules_license//licenses/spdx:Linux-man-pages-copyleft-2-para` | [reference](https://spdx.org/licenses/Linux-man-pages-copyleft-2-para.html) |
+| Linux man-pages Copyleft Variant | `@rules_license//licenses/spdx:Linux-man-pages-copyleft-var` | [reference](https://spdx.org/licenses/Linux-man-pages-copyleft-var.html) |
+| LPD Documentation License | `@rules_license//licenses/spdx:LPD-document` | [reference](https://spdx.org/licenses/LPD-document.html) |
+| lsof License | `@rules_license//licenses/spdx:lsof` | [reference](https://spdx.org/licenses/lsof.html) |
+| Lucent Public License v1.02 | `@rules_license//licenses/spdx:LPL-1.02` | [reference](https://spdx.org/licenses/LPL-1.02.html) |
+| Lucent Public License Version 1.0 | `@rules_license//licenses/spdx:LPL-1.0` | [reference](https://spdx.org/licenses/LPL-1.0.html) |
+| Lucida Bitmap Fonts License | `@rules_license//licenses/spdx:Lucida-Bitmap-Fonts` | [reference](https://spdx.org/licenses/Lucida-Bitmap-Fonts.html) |
+| LZMA SDK License (versions 9.11 to 9.20) | `@rules_license//licenses/spdx:LZMA-SDK-9.11-to-9.20` | [reference](https://spdx.org/licenses/LZMA-SDK-9.11-to-9.20.html) |
+| LZMA SDK License (versions 9.22 and beyond) | `@rules_license//licenses/spdx:LZMA-SDK-9.22` | [reference](https://spdx.org/licenses/LZMA-SDK-9.22.html) |
+| Mackerras 3-Clause - acknowledgment variant | `@rules_license//licenses/spdx:Mackerras-3-Clause-acknowledgment` | [reference](https://spdx.org/licenses/Mackerras-3-Clause-acknowledgment.html) |
+| Mackerras 3-Clause License | `@rules_license//licenses/spdx:Mackerras-3-Clause` | [reference](https://spdx.org/licenses/Mackerras-3-Clause.html) |
+| magaz License | `@rules_license//licenses/spdx:magaz` | [reference](https://spdx.org/licenses/magaz.html) |
+| mailprio License | `@rules_license//licenses/spdx:mailprio` | [reference](https://spdx.org/licenses/mailprio.html) |
+| MakeIndex License | `@rules_license//licenses/spdx:MakeIndex` | [reference](https://spdx.org/licenses/MakeIndex.html) |
+| Martin Birgmeier License | `@rules_license//licenses/spdx:Martin-Birgmeier` | [reference](https://spdx.org/licenses/Martin-Birgmeier.html) |
+| Matrix Template Library License | `@rules_license//licenses/spdx:MTLL` | [reference](https://spdx.org/licenses/MTLL.html) |
+| McPhee Slideshow License | `@rules_license//licenses/spdx:McPhee-slideshow` | [reference](https://spdx.org/licenses/McPhee-slideshow.html) |
+| metamail License | `@rules_license//licenses/spdx:metamail` | [reference](https://spdx.org/licenses/metamail.html) |
+| Michigan/Merit Networks License | `@rules_license//licenses/spdx:UMich-Merit` | [reference](https://spdx.org/licenses/UMich-Merit.html) |
+| Microsoft Limited Public License | `@rules_license//licenses/spdx:MS-LPL` | [reference](https://spdx.org/licenses/MS-LPL.html) |
+| Microsoft Public License | `@rules_license//licenses/spdx:MS-PL` | [reference](https://spdx.org/licenses/MS-PL.html) |
+| Microsoft Reciprocal License | `@rules_license//licenses/spdx:MS-RL` | [reference](https://spdx.org/licenses/MS-RL.html) |
+| Minpack License | `@rules_license//licenses/spdx:Minpack` | [reference](https://spdx.org/licenses/Minpack.html) |
+| MIT +no-false-attribs license | `@rules_license//licenses/spdx:MITNFA` | [reference](https://spdx.org/licenses/MITNFA.html) |
+| MIT Click License | `@rules_license//licenses/spdx:MIT-Click` | [reference](https://spdx.org/licenses/MIT-Click.html) |
+| MIT Festival Variant | `@rules_license//licenses/spdx:MIT-Festival` | [reference](https://spdx.org/licenses/MIT-Festival.html) |
+| MIT Khronos - old variant | `@rules_license//licenses/spdx:MIT-Khronos-old` | [reference](https://spdx.org/licenses/MIT-Khronos-old.html) |
+| MIT License | `@rules_license//licenses/spdx:MIT` | [reference](https://spdx.org/licenses/MIT.html) |
+| MIT License Modern Variant | `@rules_license//licenses/spdx:MIT-Modern-Variant` | [reference](https://spdx.org/licenses/MIT-Modern-Variant.html) |
+| MIT No Attribution | `@rules_license//licenses/spdx:MIT-0` | [reference](https://spdx.org/licenses/MIT-0.html) |
+| MIT Open Group variant | `@rules_license//licenses/spdx:MIT-open-group` | [reference](https://spdx.org/licenses/MIT-open-group.html) |
+| MIT testregex Variant | `@rules_license//licenses/spdx:MIT-testregex` | [reference](https://spdx.org/licenses/MIT-testregex.html) |
+| MIT Tom Wu Variant | `@rules_license//licenses/spdx:MIT-Wu` | [reference](https://spdx.org/licenses/MIT-Wu.html) |
+| MMIXware License | `@rules_license//licenses/spdx:MMIXware` | [reference](https://spdx.org/licenses/MMIXware.html) |
+| Motosoto License | `@rules_license//licenses/spdx:Motosoto` | [reference](https://spdx.org/licenses/Motosoto.html) |
+| Mozilla Public License 1.0 | `@rules_license//licenses/spdx:MPL-1.0` | [reference](https://spdx.org/licenses/MPL-1.0.html) |
+| Mozilla Public License 1.1 | `@rules_license//licenses/spdx:MPL-1.1` | [reference](https://spdx.org/licenses/MPL-1.1.html) |
+| Mozilla Public License 2.0 | `@rules_license//licenses/spdx:MPL-2.0` | [reference](https://spdx.org/licenses/MPL-2.0.html) |
+| Mozilla Public License 2.0 (no copyleft exception) | `@rules_license//licenses/spdx:MPL-2.0-no-copyleft-exception` | [reference](https://spdx.org/licenses/MPL-2.0-no-copyleft-exception.html) |
+| MPEG Software Simulation | `@rules_license//licenses/spdx:MPEG-SSG` | [reference](https://spdx.org/licenses/MPEG-SSG.html) |
+| mpi Permissive License | `@rules_license//licenses/spdx:mpi-permissive` | [reference](https://spdx.org/licenses/mpi-permissive.html) |
+| mpich2 License | `@rules_license//licenses/spdx:mpich2` | [reference](https://spdx.org/licenses/mpich2.html) |
+| mplus Font License | `@rules_license//licenses/spdx:mplus` | [reference](https://spdx.org/licenses/mplus.html) |
+| Mulan Permissive Software License, Version 1 | `@rules_license//licenses/spdx:MulanPSL-1.0` | [reference](https://spdx.org/licenses/MulanPSL-1.0.html) |
+| Mulan Permissive Software License, Version 2 | `@rules_license//licenses/spdx:MulanPSL-2.0` | [reference](https://spdx.org/licenses/MulanPSL-2.0.html) |
+| Multics License | `@rules_license//licenses/spdx:Multics` | [reference](https://spdx.org/licenses/Multics.html) |
+| Mup License | `@rules_license//licenses/spdx:Mup` | [reference](https://spdx.org/licenses/Mup.html) |
+| Nara Institute of Science and Technology License (2003) | `@rules_license//licenses/spdx:NAIST-2003` | [reference](https://spdx.org/licenses/NAIST-2003.html) |
+| NASA Open Source Agreement 1.3 | `@rules_license//licenses/spdx:NASA-1.3` | [reference](https://spdx.org/licenses/NASA-1.3.html) |
+| Naumen Public License | `@rules_license//licenses/spdx:Naumen` | [reference](https://spdx.org/licenses/Naumen.html) |
+| NCBI Public Domain Notice | `@rules_license//licenses/spdx:NCBI-PD` | [reference](https://spdx.org/licenses/NCBI-PD.html) |
+| NCL Source Code License | `@rules_license//licenses/spdx:NCL` | [reference](https://spdx.org/licenses/NCL.html) |
+| Net Boolean Public License v1 | `@rules_license//licenses/spdx:NBPL-1.0` | [reference](https://spdx.org/licenses/NBPL-1.0.html) |
+| Net-SNMP License | `@rules_license//licenses/spdx:Net-SNMP` | [reference](https://spdx.org/licenses/Net-SNMP.html) |
+| NetCDF license | `@rules_license//licenses/spdx:NetCDF` | [reference](https://spdx.org/licenses/NetCDF.html) |
+| Nethack General Public License | `@rules_license//licenses/spdx:NGPL` | [reference](https://spdx.org/licenses/NGPL.html) |
+| Netizen Open Source License | `@rules_license//licenses/spdx:NOSL` | [reference](https://spdx.org/licenses/NOSL.html) |
+| Netscape Public License v1.0 | `@rules_license//licenses/spdx:NPL-1.0` | [reference](https://spdx.org/licenses/NPL-1.0.html) |
+| Netscape Public License v1.1 | `@rules_license//licenses/spdx:NPL-1.1` | [reference](https://spdx.org/licenses/NPL-1.1.html) |
+| Newsletr License | `@rules_license//licenses/spdx:Newsletr` | [reference](https://spdx.org/licenses/Newsletr.html) |
+| NICTA Public Software License, Version 1.0 | `@rules_license//licenses/spdx:NICTA-1.0` | [reference](https://spdx.org/licenses/NICTA-1.0.html) |
+| NIST Public Domain Notice | `@rules_license//licenses/spdx:NIST-PD` | [reference](https://spdx.org/licenses/NIST-PD.html) |
+| NIST Public Domain Notice with license fallback | `@rules_license//licenses/spdx:NIST-PD-fallback` | [reference](https://spdx.org/licenses/NIST-PD-fallback.html) |
+| NIST Software License | `@rules_license//licenses/spdx:NIST-Software` | [reference](https://spdx.org/licenses/NIST-Software.html) |
+| No Limit Public License | `@rules_license//licenses/spdx:NLPL` | [reference](https://spdx.org/licenses/NLPL.html) |
+| Nokia Open Source License | `@rules_license//licenses/spdx:Nokia` | [reference](https://spdx.org/licenses/Nokia.html) |
+| Non-Commercial Government Licence | `@rules_license//licenses/spdx:NCGL-UK-2.0` | [reference](https://spdx.org/licenses/NCGL-UK-2.0.html) |
+| Non-Profit Open Software License 3.0 | `@rules_license//licenses/spdx:NPOSL-3.0` | [reference](https://spdx.org/licenses/NPOSL-3.0.html) |
+| Norwegian Licence for Open Government Data (NLOD) 1.0 | `@rules_license//licenses/spdx:NLOD-1.0` | [reference](https://spdx.org/licenses/NLOD-1.0.html) |
+| Norwegian Licence for Open Government Data (NLOD) 2.0 | `@rules_license//licenses/spdx:NLOD-2.0` | [reference](https://spdx.org/licenses/NLOD-2.0.html) |
+| Noweb License | `@rules_license//licenses/spdx:Noweb` | [reference](https://spdx.org/licenses/Noweb.html) |
+| NRL License | `@rules_license//licenses/spdx:NRL` | [reference](https://spdx.org/licenses/NRL.html) |
+| NTP License | `@rules_license//licenses/spdx:NTP` | [reference](https://spdx.org/licenses/NTP.html) |
+| NTP No Attribution | `@rules_license//licenses/spdx:NTP-0` | [reference](https://spdx.org/licenses/NTP-0.html) |
+| Nunit License | `@rules_license//licenses/spdx:Nunit` | [reference](https://spdx.org/licenses/Nunit.html) |
+| OAR License | `@rules_license//licenses/spdx:OAR` | [reference](https://spdx.org/licenses/OAR.html) |
+| OCLC Research Public License 2.0 | `@rules_license//licenses/spdx:OCLC-2.0` | [reference](https://spdx.org/licenses/OCLC-2.0.html) |
+| OFFIS License | `@rules_license//licenses/spdx:OFFIS` | [reference](https://spdx.org/licenses/OFFIS.html) |
+| OGC Software License, Version 1.0 | `@rules_license//licenses/spdx:OGC-1.0` | [reference](https://spdx.org/licenses/OGC-1.0.html) |
+| Open CASCADE Technology Public License | `@rules_license//licenses/spdx:OCCT-PL` | [reference](https://spdx.org/licenses/OCCT-PL.html) |
+| Open Data Commons Attribution License v1.0 | `@rules_license//licenses/spdx:ODC-By-1.0` | [reference](https://spdx.org/licenses/ODC-By-1.0.html) |
+| Open Data Commons Open Database License v1.0 | `@rules_license//licenses/spdx:ODbL-1.0` | [reference](https://spdx.org/licenses/ODbL-1.0.html) |
+| Open Data Commons Public Domain Dedication & License 1.0 | `@rules_license//licenses/spdx:PDDL-1.0` | [reference](https://spdx.org/licenses/PDDL-1.0.html) |
+| Open Government Licence - Canada | `@rules_license//licenses/spdx:OGL-Canada-2.0` | [reference](https://spdx.org/licenses/OGL-Canada-2.0.html) |
+| Open Government Licence v1.0 | `@rules_license//licenses/spdx:OGL-UK-1.0` | [reference](https://spdx.org/licenses/OGL-UK-1.0.html) |
+| Open Government Licence v2.0 | `@rules_license//licenses/spdx:OGL-UK-2.0` | [reference](https://spdx.org/licenses/OGL-UK-2.0.html) |
+| Open Government Licence v3.0 | `@rules_license//licenses/spdx:OGL-UK-3.0` | [reference](https://spdx.org/licenses/OGL-UK-3.0.html) |
+| Open Group Test Suite License | `@rules_license//licenses/spdx:OGTSL` | [reference](https://spdx.org/licenses/OGTSL.html) |
+| Open LDAP Public License 2.2.2 | `@rules_license//licenses/spdx:OLDAP-2.2.2` | [reference](https://spdx.org/licenses/OLDAP-2.2.2.html) |
+| Open LDAP Public License v1.1 | `@rules_license//licenses/spdx:OLDAP-1.1` | [reference](https://spdx.org/licenses/OLDAP-1.1.html) |
+| Open LDAP Public License v1.2 | `@rules_license//licenses/spdx:OLDAP-1.2` | [reference](https://spdx.org/licenses/OLDAP-1.2.html) |
+| Open LDAP Public License v1.3 | `@rules_license//licenses/spdx:OLDAP-1.3` | [reference](https://spdx.org/licenses/OLDAP-1.3.html) |
+| Open LDAP Public License v1.4 | `@rules_license//licenses/spdx:OLDAP-1.4` | [reference](https://spdx.org/licenses/OLDAP-1.4.html) |
+| Open LDAP Public License v2.0 (or possibly 2.0A and 2.0B) | `@rules_license//licenses/spdx:OLDAP-2.0` | [reference](https://spdx.org/licenses/OLDAP-2.0.html) |
+| Open LDAP Public License v2.0.1 | `@rules_license//licenses/spdx:OLDAP-2.0.1` | [reference](https://spdx.org/licenses/OLDAP-2.0.1.html) |
+| Open LDAP Public License v2.1 | `@rules_license//licenses/spdx:OLDAP-2.1` | [reference](https://spdx.org/licenses/OLDAP-2.1.html) |
+| Open LDAP Public License v2.2 | `@rules_license//licenses/spdx:OLDAP-2.2` | [reference](https://spdx.org/licenses/OLDAP-2.2.html) |
+| Open LDAP Public License v2.2.1 | `@rules_license//licenses/spdx:OLDAP-2.2.1` | [reference](https://spdx.org/licenses/OLDAP-2.2.1.html) |
+| Open LDAP Public License v2.3 | `@rules_license//licenses/spdx:OLDAP-2.3` | [reference](https://spdx.org/licenses/OLDAP-2.3.html) |
+| Open LDAP Public License v2.4 | `@rules_license//licenses/spdx:OLDAP-2.4` | [reference](https://spdx.org/licenses/OLDAP-2.4.html) |
+| Open LDAP Public License v2.5 | `@rules_license//licenses/spdx:OLDAP-2.5` | [reference](https://spdx.org/licenses/OLDAP-2.5.html) |
+| Open LDAP Public License v2.6 | `@rules_license//licenses/spdx:OLDAP-2.6` | [reference](https://spdx.org/licenses/OLDAP-2.6.html) |
+| Open LDAP Public License v2.7 | `@rules_license//licenses/spdx:OLDAP-2.7` | [reference](https://spdx.org/licenses/OLDAP-2.7.html) |
+| Open LDAP Public License v2.8 | `@rules_license//licenses/spdx:OLDAP-2.8` | [reference](https://spdx.org/licenses/OLDAP-2.8.html) |
+| Open Logistics Foundation License Version 1.3 | `@rules_license//licenses/spdx:OLFL-1.3` | [reference](https://spdx.org/licenses/OLFL-1.3.html) |
+| Open Market License | `@rules_license//licenses/spdx:OML` | [reference](https://spdx.org/licenses/OML.html) |
+| Open Public License v1.0 | `@rules_license//licenses/spdx:OPL-1.0` | [reference](https://spdx.org/licenses/OPL-1.0.html) |
+| Open Publication License v1.0 | `@rules_license//licenses/spdx:OPUBL-1.0` | [reference](https://spdx.org/licenses/OPUBL-1.0.html) |
+| Open Software License 1.0 | `@rules_license//licenses/spdx:OSL-1.0` | [reference](https://spdx.org/licenses/OSL-1.0.html) |
+| Open Software License 1.1 | `@rules_license//licenses/spdx:OSL-1.1` | [reference](https://spdx.org/licenses/OSL-1.1.html) |
+| Open Software License 2.0 | `@rules_license//licenses/spdx:OSL-2.0` | [reference](https://spdx.org/licenses/OSL-2.0.html) |
+| Open Software License 2.1 | `@rules_license//licenses/spdx:OSL-2.1` | [reference](https://spdx.org/licenses/OSL-2.1.html) |
+| Open Software License 3.0 | `@rules_license//licenses/spdx:OSL-3.0` | [reference](https://spdx.org/licenses/OSL-3.0.html) |
+| Open Use of Data Agreement v1.0 | `@rules_license//licenses/spdx:O-UDA-1.0` | [reference](https://spdx.org/licenses/O-UDA-1.0.html) |
+| OpenPBS v2.3 Software License | `@rules_license//licenses/spdx:OpenPBS-2.3` | [reference](https://spdx.org/licenses/OpenPBS-2.3.html) |
+| OpenSSL License | `@rules_license//licenses/spdx:OpenSSL` | [reference](https://spdx.org/licenses/OpenSSL.html) |
+| OpenSSL License - standalone | `@rules_license//licenses/spdx:OpenSSL-standalone` | [reference](https://spdx.org/licenses/OpenSSL-standalone.html) |
+| OpenVision License | `@rules_license//licenses/spdx:OpenVision` | [reference](https://spdx.org/licenses/OpenVision.html) |
+| OSET Public License version 2.1 | `@rules_license//licenses/spdx:OSET-PL-2.1` | [reference](https://spdx.org/licenses/OSET-PL-2.1.html) |
+| PADL License | `@rules_license//licenses/spdx:PADL` | [reference](https://spdx.org/licenses/PADL.html) |
+| Peer Production License | `@rules_license//licenses/spdx:PPL` | [reference](https://spdx.org/licenses/PPL.html) |
+| PHP License v3.0 | `@rules_license//licenses/spdx:PHP-3.0` | [reference](https://spdx.org/licenses/PHP-3.0.html) |
+| PHP License v3.01 | `@rules_license//licenses/spdx:PHP-3.01` | [reference](https://spdx.org/licenses/PHP-3.01.html) |
+| Pixar License | `@rules_license//licenses/spdx:Pixar` | [reference](https://spdx.org/licenses/Pixar.html) |
+| pkgconf License | `@rules_license//licenses/spdx:pkgconf` | [reference](https://spdx.org/licenses/pkgconf.html) |
+| Plexus Classworlds License | `@rules_license//licenses/spdx:Plexus` | [reference](https://spdx.org/licenses/Plexus.html) |
+| PNG Reference Library version 2 | `@rules_license//licenses/spdx:libpng-2.0` | [reference](https://spdx.org/licenses/libpng-2.0.html) |
+| pnmstitch License | `@rules_license//licenses/spdx:pnmstitch` | [reference](https://spdx.org/licenses/pnmstitch.html) |
+| PolyForm Noncommercial License 1.0.0 | `@rules_license//licenses/spdx:PolyForm-Noncommercial-1.0.0` | [reference](https://spdx.org/licenses/PolyForm-Noncommercial-1.0.0.html) |
+| PolyForm Small Business License 1.0.0 | `@rules_license//licenses/spdx:PolyForm-Small-Business-1.0.0` | [reference](https://spdx.org/licenses/PolyForm-Small-Business-1.0.0.html) |
+| PostgreSQL License | `@rules_license//licenses/spdx:PostgreSQL` | [reference](https://spdx.org/licenses/PostgreSQL.html) |
+| psfrag License | `@rules_license//licenses/spdx:psfrag` | [reference](https://spdx.org/licenses/psfrag.html) |
+| psutils License | `@rules_license//licenses/spdx:psutils` | [reference](https://spdx.org/licenses/psutils.html) |
+| Python ldap License | `@rules_license//licenses/spdx:python-ldap` | [reference](https://spdx.org/licenses/python-ldap.html) |
+| Python License 2.0 | `@rules_license//licenses/spdx:Python-2.0` | [reference](https://spdx.org/licenses/Python-2.0.html) |
+| Python License 2.0.1 | `@rules_license//licenses/spdx:Python-2.0.1` | [reference](https://spdx.org/licenses/Python-2.0.1.html) |
+| Python Software Foundation License 2.0 | `@rules_license//licenses/spdx:PSF-2.0` | [reference](https://spdx.org/licenses/PSF-2.0.html) |
+| Q Public License 1.0 | `@rules_license//licenses/spdx:QPL-1.0` | [reference](https://spdx.org/licenses/QPL-1.0.html) |
+| Q Public License 1.0 - INRIA 2004 variant | `@rules_license//licenses/spdx:QPL-1.0-INRIA-2004` | [reference](https://spdx.org/licenses/QPL-1.0-INRIA-2004.html) |
+| Qhull License | `@rules_license//licenses/spdx:Qhull` | [reference](https://spdx.org/licenses/Qhull.html) |
+| radvd License | `@rules_license//licenses/spdx:radvd` | [reference](https://spdx.org/licenses/radvd.html) |
+| Rdisc License | `@rules_license//licenses/spdx:Rdisc` | [reference](https://spdx.org/licenses/Rdisc.html) |
+| RealNetworks Public Source License v1.0 | `@rules_license//licenses/spdx:RPSL-1.0` | [reference](https://spdx.org/licenses/RPSL-1.0.html) |
+| Reciprocal Public License 1.1 | `@rules_license//licenses/spdx:RPL-1.1` | [reference](https://spdx.org/licenses/RPL-1.1.html) |
+| Reciprocal Public License 1.5 | `@rules_license//licenses/spdx:RPL-1.5` | [reference](https://spdx.org/licenses/RPL-1.5.html) |
+| Red Hat eCos Public License v1.1 | `@rules_license//licenses/spdx:RHeCos-1.1` | [reference](https://spdx.org/licenses/RHeCos-1.1.html) |
+| Ricoh Source Code Public License | `@rules_license//licenses/spdx:RSCPL` | [reference](https://spdx.org/licenses/RSCPL.html) |
+| RSA Message-Digest License | `@rules_license//licenses/spdx:RSA-MD` | [reference](https://spdx.org/licenses/RSA-MD.html) |
+| Ruby License | `@rules_license//licenses/spdx:Ruby` | [reference](https://spdx.org/licenses/Ruby.html) |
+| Ruby pty extension license | `@rules_license//licenses/spdx:Ruby-pty` | [reference](https://spdx.org/licenses/Ruby-pty.html) |
+| Sax Public Domain Notice | `@rules_license//licenses/spdx:SAX-PD` | [reference](https://spdx.org/licenses/SAX-PD.html) |
+| Sax Public Domain Notice 2.0 | `@rules_license//licenses/spdx:SAX-PD-2.0` | [reference](https://spdx.org/licenses/SAX-PD-2.0.html) |
+| Saxpath License | `@rules_license//licenses/spdx:Saxpath` | [reference](https://spdx.org/licenses/Saxpath.html) |
+| SCEA Shared Source License | `@rules_license//licenses/spdx:SCEA` | [reference](https://spdx.org/licenses/SCEA.html) |
+| Scheme Language Report License | `@rules_license//licenses/spdx:SchemeReport` | [reference](https://spdx.org/licenses/SchemeReport.html) |
+| Scheme Widget Library (SWL) Software License Agreement | `@rules_license//licenses/spdx:SWL` | [reference](https://spdx.org/licenses/SWL.html) |
+| Secure Messaging Protocol Public License | `@rules_license//licenses/spdx:SMPPL` | [reference](https://spdx.org/licenses/SMPPL.html) |
+| Sendmail License | `@rules_license//licenses/spdx:Sendmail` | [reference](https://spdx.org/licenses/Sendmail.html) |
+| Sendmail License 8.23 | `@rules_license//licenses/spdx:Sendmail-8.23` | [reference](https://spdx.org/licenses/Sendmail-8.23.html) |
+| Sendmail Open Source License v1.1 | `@rules_license//licenses/spdx:Sendmail-Open-Source-1.1` | [reference](https://spdx.org/licenses/Sendmail-Open-Source-1.1.html) |
+| Server Side Public License, v 1 | `@rules_license//licenses/spdx:SSPL-1.0` | [reference](https://spdx.org/licenses/SSPL-1.0.html) |
+| SGI Free Software License B v1.0 | `@rules_license//licenses/spdx:SGI-B-1.0` | [reference](https://spdx.org/licenses/SGI-B-1.0.html) |
+| SGI Free Software License B v1.1 | `@rules_license//licenses/spdx:SGI-B-1.1` | [reference](https://spdx.org/licenses/SGI-B-1.1.html) |
+| SGI Free Software License B v2.0 | `@rules_license//licenses/spdx:SGI-B-2.0` | [reference](https://spdx.org/licenses/SGI-B-2.0.html) |
+| SGI OpenGL License | `@rules_license//licenses/spdx:SGI-OpenGL` | [reference](https://spdx.org/licenses/SGI-OpenGL.html) |
+| SGP4 Permission Notice | `@rules_license//licenses/spdx:SGP4` | [reference](https://spdx.org/licenses/SGP4.html) |
+| SIL Open Font License 1.0 | `@rules_license//licenses/spdx:OFL-1.0` | [reference](https://spdx.org/licenses/OFL-1.0.html) |
+| SIL Open Font License 1.0 with no Reserved Font Name | `@rules_license//licenses/spdx:OFL-1.0-no-RFN` | [reference](https://spdx.org/licenses/OFL-1.0-no-RFN.html) |
+| SIL Open Font License 1.0 with Reserved Font Name | `@rules_license//licenses/spdx:OFL-1.0-RFN` | [reference](https://spdx.org/licenses/OFL-1.0-RFN.html) |
+| SIL Open Font License 1.1 | `@rules_license//licenses/spdx:OFL-1.1` | [reference](https://spdx.org/licenses/OFL-1.1.html) |
+| SIL Open Font License 1.1 with no Reserved Font Name | `@rules_license//licenses/spdx:OFL-1.1-no-RFN` | [reference](https://spdx.org/licenses/OFL-1.1-no-RFN.html) |
+| SIL Open Font License 1.1 with Reserved Font Name | `@rules_license//licenses/spdx:OFL-1.1-RFN` | [reference](https://spdx.org/licenses/OFL-1.1-RFN.html) |
+| Simple Public License 2.0 | `@rules_license//licenses/spdx:SimPL-2.0` | [reference](https://spdx.org/licenses/SimPL-2.0.html) |
+| SL License | `@rules_license//licenses/spdx:SL` | [reference](https://spdx.org/licenses/SL.html) |
+| Sleepycat License | `@rules_license//licenses/spdx:Sleepycat` | [reference](https://spdx.org/licenses/Sleepycat.html) |
+| SMAIL General Public License | `@rules_license//licenses/spdx:SMAIL-GPL` | [reference](https://spdx.org/licenses/SMAIL-GPL.html) |
+| SNIA Public License 1.1 | `@rules_license//licenses/spdx:SNIA` | [reference](https://spdx.org/licenses/SNIA.html) |
+| snprintf License | `@rules_license//licenses/spdx:snprintf` | [reference](https://spdx.org/licenses/snprintf.html) |
+| softSurfer License | `@rules_license//licenses/spdx:softSurfer` | [reference](https://spdx.org/licenses/softSurfer.html) |
+| Solderpad Hardware License v0.5 | `@rules_license//licenses/spdx:SHL-0.5` | [reference](https://spdx.org/licenses/SHL-0.5.html) |
+| Solderpad Hardware License, Version 0.51 | `@rules_license//licenses/spdx:SHL-0.51` | [reference](https://spdx.org/licenses/SHL-0.51.html) |
+| Soundex License | `@rules_license//licenses/spdx:Soundex` | [reference](https://spdx.org/licenses/Soundex.html) |
+| Spencer License 86 | `@rules_license//licenses/spdx:Spencer-86` | [reference](https://spdx.org/licenses/Spencer-86.html) |
+| Spencer License 94 | `@rules_license//licenses/spdx:Spencer-94` | [reference](https://spdx.org/licenses/Spencer-94.html) |
+| Spencer License 99 | `@rules_license//licenses/spdx:Spencer-99` | [reference](https://spdx.org/licenses/Spencer-99.html) |
+| SQLite Blessing | `@rules_license//licenses/spdx:blessing` | [reference](https://spdx.org/licenses/blessing.html) |
+| SSH OpenSSH license | `@rules_license//licenses/spdx:SSH-OpenSSH` | [reference](https://spdx.org/licenses/SSH-OpenSSH.html) |
+| SSH short notice | `@rules_license//licenses/spdx:SSH-short` | [reference](https://spdx.org/licenses/SSH-short.html) |
+| ssh-keyscan License | `@rules_license//licenses/spdx:ssh-keyscan` | [reference](https://spdx.org/licenses/ssh-keyscan.html) |
+| SSLeay License - standalone | `@rules_license//licenses/spdx:SSLeay-standalone` | [reference](https://spdx.org/licenses/SSLeay-standalone.html) |
+| Standard ML of New Jersey License | `@rules_license//licenses/spdx:SMLNJ` | [reference](https://spdx.org/licenses/SMLNJ.html) |
+| Standard ML of New Jersey License | `@rules_license//licenses/spdx:StandardML-NJ` | [reference](https://spdx.org/licenses/StandardML-NJ.html) |
+| SugarCRM Public License v1.1.3 | `@rules_license//licenses/spdx:SugarCRM-1.1.3` | [reference](https://spdx.org/licenses/SugarCRM-1.1.3.html) |
+| Sun Industry Standards Source License v1.1 | `@rules_license//licenses/spdx:SISSL` | [reference](https://spdx.org/licenses/SISSL.html) |
+| Sun Industry Standards Source License v1.2 | `@rules_license//licenses/spdx:SISSL-1.2` | [reference](https://spdx.org/licenses/SISSL-1.2.html) |
+| Sun PPP License | `@rules_license//licenses/spdx:Sun-PPP` | [reference](https://spdx.org/licenses/Sun-PPP.html) |
+| Sun PPP License (2000) | `@rules_license//licenses/spdx:Sun-PPP-2000` | [reference](https://spdx.org/licenses/Sun-PPP-2000.html) |
+| Sun Public License v1.0 | `@rules_license//licenses/spdx:SPL-1.0` | [reference](https://spdx.org/licenses/SPL-1.0.html) |
+| SunPro License | `@rules_license//licenses/spdx:SunPro` | [reference](https://spdx.org/licenses/SunPro.html) |
+| swrule License | `@rules_license//licenses/spdx:swrule` | [reference](https://spdx.org/licenses/swrule.html) |
+| Sybase Open Watcom Public License 1.0 | `@rules_license//licenses/spdx:Watcom-1.0` | [reference](https://spdx.org/licenses/Watcom-1.0.html) |
+| Symlinks License | `@rules_license//licenses/spdx:Symlinks` | [reference](https://spdx.org/licenses/Symlinks.html) |
+| Systemics BSD variant license | `@rules_license//licenses/spdx:BSD-Systemics` | [reference](https://spdx.org/licenses/BSD-Systemics.html) |
+| Systemics W3Works BSD variant license | `@rules_license//licenses/spdx:BSD-Systemics-W3Works` | [reference](https://spdx.org/licenses/BSD-Systemics-W3Works.html) |
+| Taiwan Open Government Data License, version 1.0 | `@rules_license//licenses/spdx:OGDL-Taiwan-1.0` | [reference](https://spdx.org/licenses/OGDL-Taiwan-1.0.html) |
+| TAPR Open Hardware License v1.0 | `@rules_license//licenses/spdx:TAPR-OHL-1.0` | [reference](https://spdx.org/licenses/TAPR-OHL-1.0.html) |
+| TCL/TK License | `@rules_license//licenses/spdx:TCL` | [reference](https://spdx.org/licenses/TCL.html) |
+| TCP Wrappers License | `@rules_license//licenses/spdx:TCP-wrappers` | [reference](https://spdx.org/licenses/TCP-wrappers.html) |
+| Technische Universitaet Berlin License 1.0 | `@rules_license//licenses/spdx:TU-Berlin-1.0` | [reference](https://spdx.org/licenses/TU-Berlin-1.0.html) |
+| Technische Universitaet Berlin License 2.0 | `@rules_license//licenses/spdx:TU-Berlin-2.0` | [reference](https://spdx.org/licenses/TU-Berlin-2.0.html) |
+| TermReadKey License | `@rules_license//licenses/spdx:TermReadKey` | [reference](https://spdx.org/licenses/TermReadKey.html) |
+| Text-Tabs+Wrap License | `@rules_license//licenses/spdx:TTWL` | [reference](https://spdx.org/licenses/TTWL.html) |
+| The MirOS Licence | `@rules_license//licenses/spdx:MirOS` | [reference](https://spdx.org/licenses/MirOS.html) |
+| The Parity Public License 6.0.0 | `@rules_license//licenses/spdx:Parity-6.0.0` | [reference](https://spdx.org/licenses/Parity-6.0.0.html) |
+| The Parity Public License 7.0.0 | `@rules_license//licenses/spdx:Parity-7.0.0` | [reference](https://spdx.org/licenses/Parity-7.0.0.html) |
+| The Unlicense | `@rules_license//licenses/spdx:Unlicense` | [reference](https://spdx.org/licenses/Unlicense.html) |
+| THOR Public License 1.0 | `@rules_license//licenses/spdx:TPL-1.0` | [reference](https://spdx.org/licenses/TPL-1.0.html) |
+| threeparttable License | `@rules_license//licenses/spdx:threeparttable` | [reference](https://spdx.org/licenses/threeparttable.html) |
+| Time::ParseDate License | `@rules_license//licenses/spdx:TPDL` | [reference](https://spdx.org/licenses/TPDL.html) |
+| TMate Open Source License | `@rules_license//licenses/spdx:TMate` | [reference](https://spdx.org/licenses/TMate.html) |
+| TORQUE v2.5+ Software License v1.1 | `@rules_license//licenses/spdx:TORQUE-1.1` | [reference](https://spdx.org/licenses/TORQUE-1.1.html) |
+| Transitive Grace Period Public Licence 1.0 | `@rules_license//licenses/spdx:TGPPL-1.0` | [reference](https://spdx.org/licenses/TGPPL-1.0.html) |
+| Trusster Open Source License | `@rules_license//licenses/spdx:TOSL` | [reference](https://spdx.org/licenses/TOSL.html) |
+| TrustedQSL License | `@rules_license//licenses/spdx:TrustedQSL` | [reference](https://spdx.org/licenses/TrustedQSL.html) |
+| TTYP0 License | `@rules_license//licenses/spdx:TTYP0` | [reference](https://spdx.org/licenses/TTYP0.html) |
+| Ubuntu Font Licence v1.0 | `@rules_license//licenses/spdx:Ubuntu-font-1.0` | [reference](https://spdx.org/licenses/Ubuntu-font-1.0.html) |
+| UCAR License | `@rules_license//licenses/spdx:UCAR` | [reference](https://spdx.org/licenses/UCAR.html) |
+| ulem License | `@rules_license//licenses/spdx:ulem` | [reference](https://spdx.org/licenses/ulem.html) |
+| Unicode License Agreement - Data Files and Software (2015) | `@rules_license//licenses/spdx:Unicode-DFS-2015` | [reference](https://spdx.org/licenses/Unicode-DFS-2015.html) |
+| Unicode License Agreement - Data Files and Software (2016) | `@rules_license//licenses/spdx:Unicode-DFS-2016` | [reference](https://spdx.org/licenses/Unicode-DFS-2016.html) |
+| Unicode License v3 | `@rules_license//licenses/spdx:Unicode-3.0` | [reference](https://spdx.org/licenses/Unicode-3.0.html) |
+| Unicode Terms of Use | `@rules_license//licenses/spdx:Unicode-TOU` | [reference](https://spdx.org/licenses/Unicode-TOU.html) |
+| United    Kingdom Open Parliament Licence v3.0 | `@rules_license//licenses/spdx:OPL-UK-3.0` | [reference](https://spdx.org/licenses/OPL-UK-3.0.html) |
+| Universal Permissive License v1.0 | `@rules_license//licenses/spdx:UPL-1.0` | [reference](https://spdx.org/licenses/UPL-1.0.html) |
+| University of Illinois/NCSA Open Source License | `@rules_license//licenses/spdx:NCSA` | [reference](https://spdx.org/licenses/NCSA.html) |
+| UnixCrypt License | `@rules_license//licenses/spdx:UnixCrypt` | [reference](https://spdx.org/licenses/UnixCrypt.html) |
+| Upstream Compatibility License v1.0 | `@rules_license//licenses/spdx:UCL-1.0` | [reference](https://spdx.org/licenses/UCL-1.0.html) |
+| Utah Raster Toolkit Run Length Encoded License | `@rules_license//licenses/spdx:URT-RLE` | [reference](https://spdx.org/licenses/URT-RLE.html) |
+| Vim License | `@rules_license//licenses/spdx:Vim` | [reference](https://spdx.org/licenses/Vim.html) |
+| VOSTROM Public License for Open Source | `@rules_license//licenses/spdx:VOSTROM` | [reference](https://spdx.org/licenses/VOSTROM.html) |
+| Vovida Software License v1.0 | `@rules_license//licenses/spdx:VSL-1.0` | [reference](https://spdx.org/licenses/VSL-1.0.html) |
+| W3C Software Notice and Document License (2015-05-13) | `@rules_license//licenses/spdx:W3C-20150513` | [reference](https://spdx.org/licenses/W3C-20150513.html) |
+| W3C Software Notice and License (1998-07-20) | `@rules_license//licenses/spdx:W3C-19980720` | [reference](https://spdx.org/licenses/W3C-19980720.html) |
+| W3C Software Notice and License (2002-12-31) | `@rules_license//licenses/spdx:W3C` | [reference](https://spdx.org/licenses/W3C.html) |
+| w3m License | `@rules_license//licenses/spdx:w3m` | [reference](https://spdx.org/licenses/w3m.html) |
+| Widget Workshop License | `@rules_license//licenses/spdx:Widget-Workshop` | [reference](https://spdx.org/licenses/Widget-Workshop.html) |
+| Wsuipa License | `@rules_license//licenses/spdx:Wsuipa` | [reference](https://spdx.org/licenses/Wsuipa.html) |
+| WWL License | `@rules_license//licenses/spdx:wwl` | [reference](https://spdx.org/licenses/wwl.html) |
+| wxWindows Library License | `@rules_license//licenses/spdx:wxWindows` | [reference](https://spdx.org/licenses/wxWindows.html) |
+| X.Net License | `@rules_license//licenses/spdx:Xnet` | [reference](https://spdx.org/licenses/Xnet.html) |
+| X11 License | `@rules_license//licenses/spdx:X11` | [reference](https://spdx.org/licenses/X11.html) |
+| X11 License Distribution Modification Variant | `@rules_license//licenses/spdx:X11-distribute-modifications-variant` | [reference](https://spdx.org/licenses/X11-distribute-modifications-variant.html) |
+| X11 swapped final paragraphs | `@rules_license//licenses/spdx:X11-swapped` | [reference](https://spdx.org/licenses/X11-swapped.html) |
+| Xdebug License v 1.03 | `@rules_license//licenses/spdx:Xdebug-1.03` | [reference](https://spdx.org/licenses/Xdebug-1.03.html) |
+| Xerox License | `@rules_license//licenses/spdx:Xerox` | [reference](https://spdx.org/licenses/Xerox.html) |
+| Xfig License | `@rules_license//licenses/spdx:Xfig` | [reference](https://spdx.org/licenses/Xfig.html) |
+| XFree86 License 1.1 | `@rules_license//licenses/spdx:XFree86-1.1` | [reference](https://spdx.org/licenses/XFree86-1.1.html) |
+| xinetd License | `@rules_license//licenses/spdx:xinetd` | [reference](https://spdx.org/licenses/xinetd.html) |
+| xkeyboard-config Zinoviev License | `@rules_license//licenses/spdx:xkeyboard-config-Zinoviev` | [reference](https://spdx.org/licenses/xkeyboard-config-Zinoviev.html) |
+| xlock License | `@rules_license//licenses/spdx:xlock` | [reference](https://spdx.org/licenses/xlock.html) |
+| XPP License | `@rules_license//licenses/spdx:xpp` | [reference](https://spdx.org/licenses/xpp.html) |
+| XSkat License | `@rules_license//licenses/spdx:XSkat` | [reference](https://spdx.org/licenses/XSkat.html) |
+| xzoom License | `@rules_license//licenses/spdx:xzoom` | [reference](https://spdx.org/licenses/xzoom.html) |
+| Yahoo! Public License v1.0 | `@rules_license//licenses/spdx:YPL-1.0` | [reference](https://spdx.org/licenses/YPL-1.0.html) |
+| Yahoo! Public License v1.1 | `@rules_license//licenses/spdx:YPL-1.1` | [reference](https://spdx.org/licenses/YPL-1.1.html) |
+| Zed License | `@rules_license//licenses/spdx:Zed` | [reference](https://spdx.org/licenses/Zed.html) |
+| Zeeff License | `@rules_license//licenses/spdx:Zeeff` | [reference](https://spdx.org/licenses/Zeeff.html) |
+| Zend License v2.0 | `@rules_license//licenses/spdx:Zend-2.0` | [reference](https://spdx.org/licenses/Zend-2.0.html) |
+| Zimbra Public License v1.3 | `@rules_license//licenses/spdx:Zimbra-1.3` | [reference](https://spdx.org/licenses/Zimbra-1.3.html) |
+| Zimbra Public License v1.4 | `@rules_license//licenses/spdx:Zimbra-1.4` | [reference](https://spdx.org/licenses/Zimbra-1.4.html) |
+| zlib License | `@rules_license//licenses/spdx:Zlib` | [reference](https://spdx.org/licenses/Zlib.html) |
+| zlib/libpng License with Acknowledgement | `@rules_license//licenses/spdx:zlib-acknowledgement` | [reference](https://spdx.org/licenses/zlib-acknowledgement.html) |
+| Zope Public License 1.1 | `@rules_license//licenses/spdx:ZPL-1.1` | [reference](https://spdx.org/licenses/ZPL-1.1.html) |
+| Zope Public License 2.0 | `@rules_license//licenses/spdx:ZPL-2.0` | [reference](https://spdx.org/licenses/ZPL-2.0.html) |
+| Zope Public License 2.1 | `@rules_license//licenses/spdx:ZPL-2.1` | [reference](https://spdx.org/licenses/ZPL-2.1.html) |

--- a/licenses/spdx/BUILD
+++ b/licenses/spdx/BUILD
@@ -253,6 +253,12 @@ license_kind(
 )
 
 license_kind(
+    name = "any-OSI-perl-modules",
+    conditions = [],
+    url = "https://spdx.org/licenses/any-OSI-perl-modules.json",
+)
+
+license_kind(
     name = "Apache-1.0",
     conditions = [],
     url = "https://spdx.org/licenses/Apache-1.0.html",
@@ -424,6 +430,12 @@ license_kind(
     name = "Boehm-GC",
     conditions = [],
     url = "https://spdx.org/licenses/Boehm-GC.html",
+)
+
+license_kind(
+    name = "Boehm-GC-without-fee",
+    conditions = [],
+    url = "https://spdx.org/licenses/Boehm-GC-without-fee.json",
 )
 
 license_kind(
@@ -1033,6 +1045,18 @@ license_kind(
 )
 
 license_kind(
+    name = "CC-PDM-1.0",
+    conditions = [],
+    url = "https://spdx.org/licenses/CC-PDM-1.0.json",
+)
+
+license_kind(
+    name = "CC-SA-1.0",
+    conditions = [],
+    url = "https://spdx.org/licenses/CC-SA-1.0.json",
+)
+
+license_kind(
     name = "CC0-1.0",
     conditions = [],
     url = "https://spdx.org/licenses/CC0-1.0.html",
@@ -1597,6 +1621,12 @@ license_kind(
 )
 
 license_kind(
+    name = "generic-xts",
+    conditions = [],
+    url = "https://spdx.org/licenses/generic-xts.json",
+)
+
+license_kind(
     name = "GFDL-1.1",
     conditions = [],
     url = "https://spdx.org/licenses/GFDL-1.1.html",
@@ -2140,6 +2170,12 @@ license_kind(
     name = "Inner-Net-2.0",
     conditions = [],
     url = "https://spdx.org/licenses/Inner-Net-2.0.html",
+)
+
+license_kind(
+    name = "InnoSetup",
+    conditions = [],
+    url = "https://spdx.org/licenses/InnoSetup.json",
 )
 
 license_kind(
@@ -3475,6 +3511,12 @@ license_kind(
 )
 
 license_kind(
+    name = "Sendmail-Open-Source-1.1",
+    conditions = [],
+    url = "https://spdx.org/licenses/Sendmail-Open-Source-1.1.json",
+)
+
+license_kind(
     name = "SGI-B-1.0",
     conditions = [],
     url = "https://spdx.org/licenses/SGI-B-1.0.html",
@@ -3544,6 +3586,12 @@ license_kind(
     name = "Sleepycat",
     conditions = [],
     url = "https://spdx.org/licenses/Sleepycat.html",
+)
+
+license_kind(
+    name = "SMAIL-GPL",
+    conditions = [],
+    url = "https://spdx.org/licenses/SMAIL-GPL.json",
 )
 
 license_kind(
@@ -3922,6 +3970,12 @@ license_kind(
     name = "WTFPL",
     conditions = [],
     url = "https://spdx.org/licenses/WTFPL.html",
+)
+
+license_kind(
+    name = "wwl",
+    conditions = [],
+    url = "https://spdx.org/licenses/wwl.json",
 )
 
 license_kind(

--- a/rules/license.bzl
+++ b/rules/license.bzl
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Rules for declaring the compliance licenses used by a package.
-
 """
 
 load(


### PR DESCRIPTION
- Fix the docs build (remove targets that have no glob resolves) and reexport docs by following instructions in doc_build folder
- Add an example for how to add license information to a library
- Update the SDPX kinds and add an autogenerated docs page that includes a table of all of the supported spdx kind target labels.

Most of the change to `admin/refresh_spdx/add_licenses.py` is reformatting / re-flowing.

Partially Addresses #152 

- [x] Tests pass
- [x] Tests and examples for any new features.
- [x] Appropriate changes to README are included in PR
