### PR TITLE
Fix CI at bazel last_green

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,6 +14,7 @@ module(
 # Only for development
 bazel_dep(name = "bazel_skylib", version = "1.7.1", dev_dependency = True)
 bazel_dep(name = "rules_cc", version = "0.2.2", dev_dependency = True)
+bazel_dep(name = "rules_java", version = "8.16.1", dev_dependency = True)
 bazel_dep(name = "rules_pkg", version = "1.0.1", dev_dependency = True)
 bazel_dep(name = "rules_python", version = "0.35.0", dev_dependency = True)
 bazel_dep(name = "rules_testing", version = "0.6.0", dev_dependency = True)

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -1,9 +1,14 @@
 # Test cases for license rules.
 
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_java//java:java_binary.bzl", "java_binary")
+load("@rules_java//java:java_library.bzl", "java_library")
 load("@rules_license//rules:compliance.bzl", "check_license")
 load("@rules_license//rules:license.bzl", "license")
 load("@rules_license//rules:license_kind.bzl", "license_kind")
 load("@rules_license//sample_reports:licenses_used.bzl", "licenses_used")
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
 
 package(
     default_applicable_licenses = [":license"],

--- a/tests/apps/BUILD
+++ b/tests/apps/BUILD
@@ -1,5 +1,7 @@
 # Test cases for license rules: Sample app
 
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_license//sample_reports:licenses_used.bzl", "licenses_used")
 load("@rules_python//python:defs.bzl", "py_test")
 

--- a/tests/legacy/BUILD
+++ b/tests/legacy/BUILD
@@ -1,5 +1,7 @@
 # Example of an unmigrated package.
 
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = [
     "//tests:__subpackages__",
 ])

--- a/tests/thrdparty/BUILD
+++ b/tests/thrdparty/BUILD
@@ -1,7 +1,7 @@
 # A sample library using new license rules.
 
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_license//rules:license.bzl", "license")
-# load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 
 package(
     default_applicable_licenses = [":license"],


### PR DESCRIPTION
Bazel got stricter about cc_binary (and similar) without imports.