### PR TITLE
Replace use of deprecated `Lable.workspace_name` with `Label.repo_name`

### DIFF
--- a/examples/policy_checker/license_policy.bzl
+++ b/examples/policy_checker/license_policy.bzl
@@ -29,7 +29,7 @@ def _license_policy_impl(ctx):
     provider = LicensePolicyInfo(
         name = ctx.attr.name,
         label = "@%s//%s:%s" % (
-            ctx.label.workspace_name,
+            ctx.label.repo_name,
             ctx.label.package,
             ctx.label.name,
         ),

--- a/rules/license_kind.bzl
+++ b/rules/license_kind.bzl
@@ -25,7 +25,7 @@ def _license_kind_impl(ctx):
     provider = LicenseKindInfo(
         name = ctx.attr.name,
         label = "@%s//%s:%s" % (
-            ctx.label.workspace_name,
+            ctx.label.repo_name,
             ctx.label.package,
             ctx.label.name,
         ),


### PR DESCRIPTION
The old property will be removed once [`--incompatible_config_setting_private_default_visibility`](https://github.com/bazelbuild/bazel/issues/23144) is flipped.

- [x] Tests pass
- [x] Tests and examples for any new features.
- [x] Appropriate changes to README are included in PR
